### PR TITLE
fix: align localized text generation with schema

### DIFF
--- a/sdks/python/scripts/generate_sdk.py
+++ b/sdks/python/scripts/generate_sdk.py
@@ -408,7 +408,7 @@ class SchemaConverter:
         if not current_parent_path:
             current_parent_path = self.model_paths.get(parent_class, tuple())
 
-        if self._is_multilang(prop_schema):
+        if self._is_multilang_container(prop_schema):
             self.needs_multilang = True
             type_hint = "MultiLangList"
             default_factory = "MultiLangList"
@@ -434,7 +434,7 @@ class SchemaConverter:
 
     def _default_factory(self, schema: dict[str, Any]) -> str | None:
         type_name = schema.get("type")
-        if self._is_multilang(schema):
+        if self._is_multilang_container(schema):
             return "MultiLangList"
         if type_name == "array":
             return "list"
@@ -653,10 +653,10 @@ class SchemaConverter:
         return to_pascal_case(stem)
 
     @staticmethod
-    def _is_multilang(schema: dict[str, Any]) -> bool:
+    def _is_multilang_container(schema: dict[str, Any]) -> bool:
         if isinstance(schema, list):
             return any(
-                SchemaConverter._is_multilang(item)
+                SchemaConverter._is_multilang_container(item)
                 for item in schema
                 if isinstance(item, dict)
             )
@@ -668,32 +668,47 @@ class SchemaConverter:
         if isinstance(title, str) and title.endswith("MultiLang"):
             return True
 
+        for key in ("anyOf", "oneOf"):
+            variants = schema.get(key)
+            if isinstance(variants, list):
+                return any(
+                    SchemaConverter._is_multilang_container(item)
+                    or SchemaConverter._is_multilang_item(item)
+                    for item in variants
+                    if isinstance(item, dict)
+                )
+
         if schema.get("type") == "array":
             items = schema.get("items", {})
             # items can be a schema or a list of schemas (tuples, anyOf style)
             if isinstance(items, list):
                 return any(
-                    SchemaConverter._is_multilang(item)
+                    SchemaConverter._is_multilang_container(item)
+                    or SchemaConverter._is_multilang_item(item)
                     for item in items
                     if isinstance(item, dict)
                 )
-            return SchemaConverter._is_multilang_object(items)
-
-        if schema.get("type") == "object":
-            return SchemaConverter._is_multilang_object(schema)
+            return SchemaConverter._is_multilang_item(items)
 
         return False
 
     @staticmethod
-    def _is_multilang_object(schema: dict[str, Any]) -> bool:
+    def _is_multilang_item(schema: dict[str, Any]) -> bool:
         if isinstance(schema, list):
             return any(
-                SchemaConverter._is_multilang_object(item)
+                SchemaConverter._is_multilang_item(item)
                 for item in schema
                 if isinstance(item, dict)
             )
         if not isinstance(schema, dict):
             return False
+
+        if "$ref" in schema and schema["$ref"].endswith("LocalizedTextItem"):
+            return True
+
+        if "$ref" in schema and re.search(r"LocalizedText(?:\d+)?Item$", schema["$ref"]):
+            return True
+
         properties = schema.get("properties", {})
         return "@xml:lang" in properties and "#text" in properties
 
@@ -723,12 +738,27 @@ class SchemaConverter:
                 candidate = self._resolve_ref(schema["$ref"])
                 if candidate and candidate[0].isupper() and candidate.isidentifier():
                     base_class = candidate
+                ref_schema = self._resolve_local_ref_schema(schema["$ref"])
+                if ref_schema is not None:
+                    normalized_ref = self._normalize_object_schema(ref_schema)
+                    properties = self._merge_property_maps(
+                        properties,
+                        normalized_ref["properties"],
+                    )
+                    required |= normalized_ref["required"]
+                    if not description:
+                        description = normalized_ref["description"]
+                    if normalized_ref["base_class"] and not base_class:
+                        base_class = normalized_ref["base_class"]
 
         all_of = schema.get("allOf")
         if isinstance(all_of, list):
             for part in all_of:
                 normalized = self._normalize_object_schema(part)
-                properties.update(normalized["properties"])
+                properties = self._merge_property_maps(
+                    properties,
+                    normalized["properties"],
+                )
                 required |= normalized["required"]
                 if not description:
                     description = normalized["description"]
@@ -736,7 +766,7 @@ class SchemaConverter:
                     base_class = normalized["base_class"]
 
         if "properties" in schema and isinstance(schema["properties"], dict):
-            properties.update(schema["properties"])
+            properties = self._merge_property_maps(properties, schema["properties"])
 
         required |= set(schema.get("required", []))
 
@@ -746,6 +776,56 @@ class SchemaConverter:
             "description": description,
             "base_class": base_class,
         }
+
+    def _resolve_local_ref_schema(self, ref: str) -> dict[str, Any] | None:
+        if not ref.startswith("#/$defs/"):
+            return None
+
+        ref_name = ref.split("/")[-1]
+        defs = self.schema.get("$defs", {})
+        resolved = defs.get(ref_name)
+        return resolved if isinstance(resolved, dict) else None
+
+    @staticmethod
+    def _merge_property_schema(base: Any, new: Any) -> dict[str, Any]:
+        if not isinstance(base, dict):
+            return dict(new) if isinstance(new, dict) else {}
+        if not isinstance(new, dict):
+            return dict(base)
+
+        merged = {**base, **new}
+
+        if "properties" in base or "properties" in new:
+            merged["properties"] = {
+                **(base.get("properties", {}) or {}),
+                **(new.get("properties", {}) or {}),
+            }
+
+        if "required" in base or "required" in new:
+            merged["required"] = list(
+                {
+                    *(base.get("required", []) or []),
+                    *(new.get("required", []) or []),
+                }
+            )
+
+        if "not" in base and "not" in new:
+            merged["not"] = {**base["not"], **new["not"]}
+
+        return merged
+
+    def _merge_property_maps(
+        self,
+        base: dict[str, Any],
+        new: dict[str, Any],
+    ) -> dict[str, Any]:
+        merged = dict(base)
+        for key, value in new.items():
+            if key in merged:
+                merged[key] = self._merge_property_schema(merged[key], value)
+            else:
+                merged[key] = value
+        return merged
 
     def _collect_constraints(self, schema: dict[str, Any]) -> dict[str, str]:
         constraints: dict[str, str] = {}
@@ -911,7 +991,7 @@ class SchemaConverter:
     def _infer_scalar(self, schema: Any) -> ScalarInfo | None:
         if not isinstance(schema, dict):
             return None
-        if self._is_multilang(schema):
+        if self._is_multilang_container(schema):
             return ScalarInfo(base_type="MultiLangList", needs_multilang=True, description=schema.get("description"))
         if "$ref" in schema:
             ref_scalar = self._lookup_scalar(schema["$ref"])

--- a/sdks/python/src/tidas_sdk/generated/__init__.py
+++ b/sdks/python/src/tidas_sdk/generated/__init__.py
@@ -1,6 +1,7 @@
 """Exports for auto-generated models."""
 from __future__ import annotations
 
+from .tidas_data_types import LocalizedTextItem
 from .tidas_data_types import LocalizedText500Item
 from .tidas_data_types import LocalizedText1000Item
 from .tidas_data_types import GlobalReferenceTypeVariant0
@@ -8,7 +9,6 @@ from .tidas_data_types import GlobalReferenceTypeVariant1Item
 from .tidas_data_types import DataTypes
 from .tidas_data_types import CASNumber
 from .tidas_data_types import FT
-from .tidas_data_types import LocalizedTextItem
 from .tidas_data_types import Int1
 from .tidas_data_types import Int5
 from .tidas_data_types import Int6
@@ -5817,6 +5817,7 @@ from .tidas_unitgroups_category import UnitgroupsCategory
 from .tidas_unitgroups_category import UnitGroup
 
 __all__ = [
+    'LocalizedTextItem',
     'LocalizedText500Item',
     'LocalizedText1000Item',
     'GlobalReferenceTypeVariant0',
@@ -5824,7 +5825,6 @@ __all__ = [
     'DataTypes',
     'CASNumber',
     'FT',
-    'LocalizedTextItem',
     'Int1',
     'Int5',
     'Int6',

--- a/sdks/python/src/tidas_sdk/generated/tidas_data_types.py
+++ b/sdks/python/src/tidas_sdk/generated/tidas_data_types.py
@@ -4,7 +4,7 @@ Source: tidas_data_types.json
 """
 from __future__ import annotations
 
-from typing import Annotated, Any
+from typing import Annotated
 
 from pydantic import Field
 from tidas_sdk.core.base import TidasBaseModel
@@ -16,8 +16,6 @@ from datetime import datetime
 CASNumber = Annotated[str, Field(pattern='^[0-9]{2,7}-[0-9]{2}-[0-9]$')]
 # Free text with an unlimited length.
 FT = str
-# Language-tagged text with optional script checks for selected languages.
-LocalizedTextItem = MultiLangList
 # 1-digit integer number
 Int1 = Annotated[str, Field(pattern='^[0-9]$')]
 # 5-digit integer number
@@ -47,13 +45,20 @@ Year = Annotated[int, Field(ge=1000, le=9999)]
 # Date and time format acc. to ISO 8601
 DateTime = datetime
 
-class LocalizedText500Item(TidasBaseModel):
-    """Language-tagged text with a maximum length of 500 characters."""
-    text: Any | None = Field(default=None, alias='#text', max_length=500)
+class LocalizedTextItem(TidasBaseModel):
+    """Language-tagged text with optional script checks for selected languages."""
+    xml_lang: str = Field(default=..., alias='@xml:lang')
+    text: str = Field(default=..., alias='#text')
 
-class LocalizedText1000Item(TidasBaseModel):
+class LocalizedText500Item(LocalizedTextItem):
+    """Language-tagged text with a maximum length of 500 characters."""
+    xml_lang: str = Field(default=..., alias='@xml:lang')
+    text: str = Field(default=..., alias='#text', max_length=500)
+
+class LocalizedText1000Item(LocalizedTextItem):
     """Language-tagged text with a maximum length of 1000 characters."""
-    text: Any | None = Field(default=None, alias='#text', max_length=1000)
+    xml_lang: str = Field(default=..., alias='@xml:lang')
+    text: str = Field(default=..., alias='#text', max_length=1000)
 
 class GlobalReferenceTypeVariant0(TidasBaseModel):
     type: str = Field(default=..., alias='@type')

--- a/sdks/python/tests/test_generated_localized_text.py
+++ b/sdks/python/tests/test_generated_localized_text.py
@@ -1,0 +1,69 @@
+from pathlib import Path
+import sys
+from typing import get_args, get_origin
+
+import pytest
+from pydantic import ValidationError
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from tidas_sdk.generated.tidas_data_types import (
+    FTMultiLang,
+    LocalizedText1000Item,
+    LocalizedText500Item,
+    LocalizedTextItem,
+    STMultiLang,
+    StringMultiLang,
+)
+
+
+def test_localized_text_item_requires_schema_fields() -> None:
+    item = LocalizedTextItem.model_validate(
+        {"@xml:lang": "en", "#text": "English title"}
+    )
+
+    assert item.xml_lang == "en"
+    assert item.text == "English title"
+
+    with pytest.raises(ValidationError):
+        LocalizedTextItem.model_validate({"#text": "English title"})
+
+    with pytest.raises(ValidationError):
+        LocalizedTextItem.model_validate({"@xml:lang": "en"})
+
+
+def test_localized_text_specializations_preserve_max_length() -> None:
+    LocalizedText500Item.model_validate(
+        {"@xml:lang": "fr", "#text": "a" * 500}
+    )
+    LocalizedText1000Item.model_validate(
+        {"@xml:lang": "fr", "#text": "a" * 1000}
+    )
+
+    with pytest.raises(ValidationError):
+        LocalizedText500Item.model_validate(
+            {"@xml:lang": "fr", "#text": "a" * 501}
+        )
+
+    with pytest.raises(ValidationError):
+        LocalizedText1000Item.model_validate(
+            {"@xml:lang": "fr", "#text": "a" * 1001}
+        )
+
+
+def test_multilang_aliases_reference_localized_text_models() -> None:
+    string_array_type, string_item_type = get_args(StringMultiLang)
+    st_array_type, st_item_type = get_args(STMultiLang)
+    ft_array_type, ft_item_type = get_args(FTMultiLang)
+
+    assert get_origin(string_array_type) is list
+    assert get_args(string_array_type) == (LocalizedText500Item,)
+    assert string_item_type is LocalizedText500Item
+
+    assert get_origin(st_array_type) is list
+    assert get_args(st_array_type) == (LocalizedText1000Item,)
+    assert st_item_type is LocalizedText1000Item
+
+    assert get_origin(ft_array_type) is list
+    assert get_args(ft_array_type) == (LocalizedTextItem,)
+    assert ft_item_type is LocalizedTextItem

--- a/sdks/typescript/scripts/generate-zod-schemas.ts
+++ b/sdks/typescript/scripts/generate-zod-schemas.ts
@@ -206,33 +206,78 @@ async function postProcessZodSchema(schemaFile: string): Promise<void> {
   if (schemaFile.includes('tidas_data_types')) {
     console.log('   ℹ️  Applying manual optimizations for tidas_data_types');
 
-    // Replace z.any() multi-lang schemas with proper typed schemas
-    const manualOptimizations = content.replace(
-      /const MultiLangArrayLikeSchema = z\.any\(\);[\s\S]*?const MultiLangItemClassSchema = z\.any\(\);[\s\S]*?export const StringMultiLangSchema = z\.union\(\[[\s\S]*?\]\);[\s\S]*?export const STMultiLangSchema = z\.union\(\[[\s\S]*?\]\);[\s\S]*?export const FTMultiLangSchema = z\.union\(\[[\s\S]*?\]\);/,
-      `// Multi-language item schema: { "#text": "value", "@xml:lang": "en" }
-const MultiLangItemSchema = z.object({
-  '#text': z.string(),
+    let manualOptimizations = content.replace(
+      /export const LocalizedTextItemSchema = z\.object\(\{[\s\S]*?\}\);\n\nexport const LocalizedText500ItemSchema = z\.object\(\{[\s\S]*?\}\);\n\nexport const LocalizedText1000ItemSchema = z\.object\(\{[\s\S]*?\}\);\n/,
+      `const chineseCharacterPattern = /[\\u3400-\\u4DBF\\u4E00-\\u9FFF\\uF900-\\uFAFF]/;
+
+const addLocalizedTextLanguageChecks = (
+  value: { '@xml:lang': string; '#text': string },
+  ctx: z.RefinementCtx
+) => {
+  const lang = value['@xml:lang'];
+  const text = value['#text'];
+
+  if (/^[zZ][hH](?:-|$)/.test(lang) && !chineseCharacterPattern.test(text)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['#text'],
+      message:
+        "@xml:lang values starting with 'zh' must include at least one Chinese character",
+    });
+  }
+
+  if (/^[eE][nN](?:-|$)/.test(lang) && chineseCharacterPattern.test(text)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['#text'],
+      message:
+        "@xml:lang values starting with 'en' must not contain Chinese characters",
+    });
+  }
+};
+
+const LocalizedTextItemBaseSchema = z.object({
   '@xml:lang': z.string(),
+  '#text': z.string(),
 });
 
-// Multi-language can be either a single item or an array of items
-const MultiLangArrayLikeSchema = z.array(MultiLangItemSchema);
+export const LocalizedTextItemSchema = LocalizedTextItemBaseSchema.superRefine(
+  addLocalizedTextLanguageChecks
+);
 
-const MultiLangItemClassSchema = MultiLangItemSchema;
+export const LocalizedText500ItemSchema =
+  LocalizedTextItemBaseSchema.extend({
+    '#text': z.string().max(500),
+  }).superRefine(addLocalizedTextLanguageChecks);
 
-export const StringMultiLangSchema = z.union([
-  MultiLangItemClassSchema,      // Single object
-  MultiLangArrayLikeSchema,      // Array of objects
-]);
+export const LocalizedText1000ItemSchema =
+  LocalizedTextItemBaseSchema.extend({
+    '#text': z.string().max(1000),
+  }).superRefine(addLocalizedTextLanguageChecks);
+`
+    );
 
-export const STMultiLangSchema = z.union([
-  MultiLangItemClassSchema,      // Single object
-  MultiLangArrayLikeSchema,      // Array of objects
-]);
+    manualOptimizations = manualOptimizations.replace(
+      /export const StringMultiLangSchema = z\.union\(\[[\s\S]*?\]\);/,
+      `export const StringMultiLangSchema = z.union([
+  z.array(LocalizedText500ItemSchema),
+  LocalizedText500ItemSchema,
+]);`
+    );
 
-export const FTMultiLangSchema = z.union([
-  MultiLangItemClassSchema,      // Single object
-  MultiLangArrayLikeSchema,      // Array of objects
+    manualOptimizations = manualOptimizations.replace(
+      /export const STMultiLangSchema = z\.union\(\[[\s\S]*?\]\);/,
+      `export const STMultiLangSchema = z.union([
+  z.array(LocalizedText1000ItemSchema),
+  LocalizedText1000ItemSchema,
+]);`
+    );
+
+    manualOptimizations = manualOptimizations.replace(
+      /export const FTMultiLangSchema = z\.union\(\[[\s\S]*?\]\);/,
+      `export const FTMultiLangSchema = z.union([
+  z.array(LocalizedTextItemSchema),
+  LocalizedTextItemSchema,
 ]);`
     );
 

--- a/sdks/typescript/scripts/json-schema-to-typescript.ts
+++ b/sdks/typescript/scripts/json-schema-to-typescript.ts
@@ -46,6 +46,7 @@ class JsonSchemaToTypeScript {
   private processedRefs: Set<string> = new Set();
   private referencedTypes: Set<string> = new Set();
   private currentFile?: string;
+  private rootSchema?: any;
 
   constructor(config: TypeScriptConfig) {
     this.config = config;
@@ -62,6 +63,7 @@ class JsonSchemaToTypeScript {
     this.processedRefs = new Set();
     this.referencedTypes = new Set();
     this.currentFile = currentFile;
+    this.rootSchema = schema;
 
     // --- 插入 MultiLangArray class 和 MultiLangItem type ---
     // 检查 schema 是否包含 *MultiLang 类型
@@ -164,16 +166,6 @@ class JsonSchemaToTypeScript {
     }
     this.processedRefs.add(name);
 
-    // 检查是否为 *MultiLang 类型
-    if (name.endsWith('MultiLang')) {
-      // 直接生成 type alias 指向 MultiLangArrayLike | MultiLangItemClass
-      this.typeDefinitions.set(
-        name,
-        `${this.config.exportStyle} type ${name} = MultiLangArrayLike | MultiLangItemClass;`
-      );
-      return;
-    }
-
     const tsType = this.getTypeScriptType(schema);
     if (schema.anyOf || schema.oneOf) {
       // For union types, create a simple type alias with JSDoc
@@ -183,9 +175,12 @@ class JsonSchemaToTypeScript {
         ? `${jsdoc}\n${this.config.exportStyle} type ${name} = ${tsType};`
         : `${this.config.exportStyle} type ${name} = ${tsType};`;
       this.typeDefinitions.set(name, definition);
-    } else if (schema.type === 'object' && schema.properties) {
+    } else if (this.normalizeObjectSchema(schema)) {
       // For objects, create an interface
-      const interfaceContent = this.processObject(schema, name);
+      const interfaceContent = this.processObject(
+        this.normalizeObjectSchema(schema),
+        name
+      );
       this.typeDefinitions.set(name, interfaceContent);
     } else {
       // For simple types, create a type alias with JSDoc
@@ -244,6 +239,144 @@ class JsonSchemaToTypeScript {
 
     lines.push('}');
     return lines.join('\n');
+  }
+
+  private resolveLocalRefSchema(refPath: string): any | null {
+    if (!refPath.startsWith('#/$defs/')) {
+      return null;
+    }
+
+    const refName = refPath.split('/').pop();
+    if (!refName) {
+      return null;
+    }
+
+    return this.rootSchema?.$defs?.[refName] ?? null;
+  }
+
+  private mergePropertySchema(base: any, extension: any): any {
+    if (!base || typeof base !== 'object') {
+      return { ...extension };
+    }
+    if (!extension || typeof extension !== 'object') {
+      return { ...base };
+    }
+
+    const merged: any = { ...base, ...extension };
+
+    if (base.properties || extension.properties) {
+      merged.properties = {
+        ...(base.properties || {}),
+        ...(extension.properties || {}),
+      };
+    }
+
+    if (base.required || extension.required) {
+      merged.required = Array.from(
+        new Set([...(base.required || []), ...(extension.required || [])])
+      );
+    }
+
+    if (base.not && extension.not) {
+      merged.not = { ...base.not, ...extension.not };
+    }
+
+    return merged;
+  }
+
+  private mergeObjectSchemas(base: any, extension: any): any {
+    const merged: any = {
+      ...(base || {}),
+      ...(extension || {}),
+    };
+
+    if ((base?.type === 'object') || (extension?.type === 'object')) {
+      merged.type = 'object';
+    }
+
+    const baseProperties = base?.properties || {};
+    const extensionProperties = extension?.properties || {};
+    const propertyNames = new Set([
+      ...Object.keys(baseProperties),
+      ...Object.keys(extensionProperties),
+    ]);
+
+    if (propertyNames.size > 0) {
+      merged.properties = {};
+      for (const propertyName of propertyNames) {
+        if (propertyName in baseProperties && propertyName in extensionProperties) {
+          merged.properties[propertyName] = this.mergePropertySchema(
+            baseProperties[propertyName],
+            extensionProperties[propertyName]
+          );
+          continue;
+        }
+
+        merged.properties[propertyName] =
+          extensionProperties[propertyName] ?? baseProperties[propertyName];
+      }
+    }
+
+    merged.required = Array.from(
+      new Set([...(base?.required || []), ...(extension?.required || [])])
+    );
+
+    if (base?.description && !extension?.description) {
+      merged.description = base.description;
+    }
+
+    return merged;
+  }
+
+  private normalizeObjectSchema(schema: any): any | null {
+    if (!schema || typeof schema !== 'object') {
+      return null;
+    }
+
+    let normalized: any = {};
+    let hasObjectShape = false;
+
+    if (schema.$ref) {
+      const refSchema = this.resolveLocalRefSchema(schema.$ref);
+      const normalizedRef = refSchema
+        ? this.normalizeObjectSchema(refSchema)
+        : null;
+      if (normalizedRef) {
+        normalized = this.mergeObjectSchemas(normalized, normalizedRef);
+        hasObjectShape = true;
+      }
+    }
+
+    if (Array.isArray(schema.allOf)) {
+      for (const entry of schema.allOf) {
+        const normalizedEntry = this.normalizeObjectSchema(entry);
+        if (!normalizedEntry) {
+          continue;
+        }
+        normalized = this.mergeObjectSchemas(normalized, normalizedEntry);
+        hasObjectShape = true;
+      }
+    }
+
+    if (schema.type === 'object' || schema.properties) {
+      normalized = this.mergeObjectSchemas(normalized, {
+        type: 'object',
+        properties: schema.properties || {},
+        required: schema.required || [],
+        description: schema.description,
+      });
+      hasObjectShape = true;
+    }
+
+    if (!hasObjectShape) {
+      return null;
+    }
+
+    if (schema.description) {
+      normalized.description = schema.description;
+    }
+
+    return normalized;
   }
 
   private hasConstraints(schema: any): boolean {
@@ -618,6 +751,21 @@ class JsonSchemaToTypeScript {
         return optionType;
       });
       return types.join(' | ');
+    }
+
+    // Handle allOf
+    if (schema.allOf) {
+      const normalizedObjectSchema = this.normalizeObjectSchema(schema);
+      if (normalizedObjectSchema) {
+        return this.getTypeScriptType(normalizedObjectSchema);
+      }
+
+      const intersectionTypes = schema.allOf
+        .map((entry: any) => this.getTypeScriptType(entry))
+        .filter((entry: string) => entry && entry !== 'any');
+      if (intersectionTypes.length > 0) {
+        return intersectionTypes.join(' & ');
+      }
     }
 
     // Handle arrays

--- a/sdks/typescript/src/schemas/tidas_data_types.schema.test.ts
+++ b/sdks/typescript/src/schemas/tidas_data_types.schema.test.ts
@@ -1,0 +1,78 @@
+import {
+  LocalizedText500ItemSchema,
+  LocalizedTextItemSchema,
+  STMultiLangSchema,
+  StringMultiLangSchema,
+} from './tidas_data_types.schema';
+
+describe('localized text schemas', () => {
+  it('requires both @xml:lang and #text', () => {
+    expect(
+      LocalizedTextItemSchema.safeParse({
+        '@xml:lang': 'en',
+      }).success
+    ).toBe(false);
+
+    expect(
+      LocalizedTextItemSchema.safeParse({
+        '#text': 'English title',
+      }).success
+    ).toBe(false);
+  });
+
+  it('enforces localized language checks for zh and en values', () => {
+    expect(
+      StringMultiLangSchema.safeParse({
+        '@xml:lang': 'zh-CN',
+        '#text': 'english only',
+      }).success
+    ).toBe(false);
+
+    expect(
+      StringMultiLangSchema.safeParse({
+        '@xml:lang': 'en',
+        '#text': 'English 中文',
+      }).success
+    ).toBe(false);
+
+    expect(
+      StringMultiLangSchema.safeParse([
+        {
+          '@xml:lang': 'zh',
+          '#text': '中文名称',
+        },
+        {
+          '@xml:lang': 'en-US',
+          '#text': 'English title',
+        },
+        {
+          '@xml:lang': 'fr',
+          '#text': 'Bonjour 中文',
+        },
+      ]).success
+    ).toBe(true);
+  });
+
+  it('preserves max length limits for localized text variants', () => {
+    expect(
+      LocalizedText500ItemSchema.safeParse({
+        '@xml:lang': 'fr',
+        '#text': 'a'.repeat(500),
+      }).success
+    ).toBe(true);
+
+    expect(
+      LocalizedText500ItemSchema.safeParse({
+        '@xml:lang': 'fr',
+        '#text': 'a'.repeat(501),
+      }).success
+    ).toBe(false);
+
+    expect(
+      STMultiLangSchema.safeParse({
+        '@xml:lang': 'en',
+        '#text': 'a'.repeat(1001),
+      }).success
+    ).toBe(false);
+  });
+});

--- a/sdks/typescript/src/schemas/tidas_data_types.schema.ts
+++ b/sdks/typescript/src/schemas/tidas_data_types.schema.ts
@@ -5,6 +5,58 @@ export const CASNumberSchema = z.string().regex(/^[0-9]{2,7}-[0-9]{2}-[0-9]$/);
 
 export const FTSchema = z.string();
 
+const chineseCharacterPattern = /[\u3400-\u4DBF\u4E00-\u9FFF\uF900-\uFAFF]/;
+
+const addLocalizedTextLanguageChecks = (
+  value: { '@xml:lang': string; '#text': string },
+  ctx: z.RefinementCtx
+) => {
+  const lang = value['@xml:lang'];
+  const text = value['#text'];
+
+  if (/^[zZ][hH](?:-|$)/.test(lang) && !chineseCharacterPattern.test(text)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['#text'],
+      message:
+        "@xml:lang values starting with 'zh' must include at least one Chinese character",
+    });
+  }
+
+  if (/^[eE][nN](?:-|$)/.test(lang) && chineseCharacterPattern.test(text)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['#text'],
+      message:
+        "@xml:lang values starting with 'en' must not contain Chinese characters",
+    });
+  }
+};
+
+const LocalizedTextItemBaseSchema = z.object({
+  '@xml:lang': z.string(),
+  '#text': z.string(),
+});
+
+export const LocalizedTextItemSchema = LocalizedTextItemBaseSchema.superRefine(
+  addLocalizedTextLanguageChecks
+);
+
+export const LocalizedText500ItemSchema =
+  LocalizedTextItemBaseSchema.extend({
+    '#text': z.string().max(500),
+  }).superRefine(addLocalizedTextLanguageChecks);
+
+export const LocalizedText1000ItemSchema =
+  LocalizedTextItemBaseSchema.extend({
+    '#text': z.string().max(1000),
+  }).superRefine(addLocalizedTextLanguageChecks);
+
+export const StringMultiLangSchema = z.union([
+  z.array(LocalizedText500ItemSchema),
+  LocalizedText500ItemSchema,
+]);
+
 export const Int1Schema = z.string().regex(/^[0-9]$/);
 
 export const Int5Schema = z.string().regex(/^(0|[1-9]\d{0,4})$/);
@@ -29,44 +81,14 @@ export const STSchema = z.string().max(1000);
 
 export const StringSchema = z.string().min(1).max(500);
 
-export const GISSchema = z
-  .string()
-  .regex(
-    /^\s*[+-]?((90(\.0+)?)|([0-8]?\d(\.\d+)?))\s*;\s*[+-]?((180(\.0+)?)|((1[0-7]\d|[0-9]?\d)(\.\d+)?))\s*$/
-  );
-
-export const UUIDSchema = z
-  .string()
-  .regex(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
-
-export const YearSchema = z.number().min(1000).max(9999);
-
-export const dateTimeSchema = z.string().datetime();
-
-// Multi-language item schema: { "#text": "value", "@xml:lang": "en" }
-const MultiLangItemSchema = z.object({
-  '#text': z.string(),
-  '@xml:lang': z.string(),
-});
-
-// Multi-language can be either a single item or an array of items
-const MultiLangArrayLikeSchema = z.array(MultiLangItemSchema);
-
-const MultiLangItemClassSchema = MultiLangItemSchema;
-
-export const StringMultiLangSchema = z.union([
-  MultiLangItemClassSchema,      // Single object
-  MultiLangArrayLikeSchema,      // Array of objects
-]);
-
 export const STMultiLangSchema = z.union([
-  MultiLangItemClassSchema,      // Single object
-  MultiLangArrayLikeSchema,      // Array of objects
+  z.array(LocalizedText1000ItemSchema),
+  LocalizedText1000ItemSchema,
 ]);
 
 export const FTMultiLangSchema = z.union([
-  MultiLangItemClassSchema,      // Single object
-  MultiLangArrayLikeSchema,      // Array of objects
+  z.array(LocalizedTextItemSchema),
+  LocalizedTextItemSchema,
 ]);
 
 export const GlobalReferenceTypeSchema = z.union([
@@ -87,3 +109,17 @@ export const GlobalReferenceTypeSchema = z.union([
     })
   ),
 ]);
+
+export const GISSchema = z
+  .string()
+  .regex(
+    /^\s*[+-]?((90(\.0+)?)|([0-8]?\d(\.\d+)?))\s*;\s*[+-]?((180(\.0+)?)|((1[0-7]\d|[0-9]?\d)(\.\d+)?))\s*$/
+  );
+
+export const UUIDSchema = z
+  .string()
+  .regex(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+
+export const YearSchema = z.number().min(1000).max(9999);
+
+export const dateTimeSchema = z.string().datetime();

--- a/sdks/typescript/src/types/tidas_data_types.ts
+++ b/sdks/typescript/src/types/tidas_data_types.ts
@@ -4,13 +4,6 @@
  * and run the generation script to regenerate this file.
  */
 
-import {
-  MultiLangArray,
-  MultiLangArrayLike,
-  MultiLangItem,
-  MultiLangItemClass,
-} from './multi-lang-types';
-
 /**
  * CAS Number, leading zeros are requried.
  *
@@ -21,7 +14,28 @@ export type CASNumber = string;
  * Free text with an unlimited length.
  */
 export type FT = string;
-export type StringMultiLang = MultiLangArrayLike | MultiLangItemClass;
+export interface LocalizedTextItem {
+  '@xml:lang': string;
+  '#text': string;
+}
+export interface LocalizedText500Item {
+  '@xml:lang': string;
+  /**
+   * @maxLength 500
+   */
+  '#text': string;
+}
+export interface LocalizedText1000Item {
+  '@xml:lang': string;
+  /**
+   * @maxLength 1000
+   */
+  '#text': string;
+}
+/**
+ * Multi-language string with a maximum length of 500 characters
+ */
+export type StringMultiLang = LocalizedText500Item[] | LocalizedText500Item;
 /**
  * 1-digit integer number
  *
@@ -77,8 +91,14 @@ export type ST = string;
  * @maxLength 500
  */
 export type String = string;
-export type STMultiLang = MultiLangArrayLike | MultiLangItemClass;
-export type FTMultiLang = MultiLangArrayLike | MultiLangItemClass;
+/**
+ * Multi-lang short text with a maximum length of 1000 characters.
+ */
+export type STMultiLang = LocalizedText1000Item[] | LocalizedText1000Item;
+/**
+ * Multi-lang free text with an unlimited length.
+ */
+export type FTMultiLang = LocalizedTextItem[] | LocalizedTextItem;
 /**
  * Represents a reference to another dataset or file. Either refObjectId and version, or uri, or both have to be specified.
  */


### PR DESCRIPTION
Closes #7

## Summary
- preserve `LocalizedTextItem`, `LocalizedText500Item`, and `LocalizedText1000Item` as concrete generated models/types instead of collapsing them into generic multi-lang aliases
- keep TypeScript Zod schemas aligned with the upstream schema, including 500/1000 max-length limits and localized `zh*` / `en*` text checks
- distinguish Python multi-lang container fields from localized text item objects so generated unions point to the correct item models
- add regression tests for both TypeScript and Python generation results

## Validation
- `./scripts/ci/generate-typescript-sdk.sh`
- `./scripts/ci/generate-python-sdk.sh`
- `npm test -- --runInBand tidas_data_types.schema.test.ts`
- `npm run build`
- `uv run pytest -q tests/test_generated_localized_text.py`