### PR TITLE
feat: automate upstream SDK sync releases

### DIFF
--- a/.github/workflows/sync-from-tidas-tools.yml
+++ b/.github/workflows/sync-from-tidas-tools.yml
@@ -1,0 +1,349 @@
+name: Sync From tidas-tools
+
+on:
+  repository_dispatch:
+    types:
+      - tidas_tools_changed
+  workflow_dispatch:
+    inputs:
+      tidas_tools_sha:
+        description: Exact tiangong-lca/tidas-tools commit SHA to sync from. Leave empty to use main.
+        required: false
+        type: string
+      packages:
+        description: Package families to regenerate.
+        required: true
+        default: both
+        type: choice
+        options:
+          - both
+          - typescript
+          - python
+      typescript_bump:
+        description: TypeScript version bump level.
+        required: true
+        default: patch
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      python_bump:
+        description: Python version bump level.
+        required: true
+        default: patch
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      reason:
+        description: Optional note explaining why this sync is running.
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    env:
+      AUTOMATION_TOKEN: ${{ secrets.TIDAS_RELEASE_AUTOMATION_TOKEN }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate automation token
+        run: |
+          if [ -z "$AUTOMATION_TOKEN" ]; then
+            echo "error: missing TIDAS_RELEASE_AUTOMATION_TOKEN secret" >&2
+            exit 1
+          fi
+
+      - name: Resolve sync request
+        id: request
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_PATH: ${{ github.event_path }}
+          INPUT_TIDAS_TOOLS_SHA: ${{ github.event.inputs.tidas_tools_sha }}
+          INPUT_PACKAGES: ${{ github.event.inputs.packages }}
+          INPUT_TYPESCRIPT_BUMP: ${{ github.event.inputs.typescript_bump }}
+          INPUT_PYTHON_BUMP: ${{ github.event.inputs.python_bump }}
+          INPUT_REASON: ${{ github.event.inputs.reason }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          event_name = os.environ["EVENT_NAME"]
+          outputs_path = Path(os.environ["GITHUB_OUTPUT"])
+
+          requested_sha = ""
+          requested_ref = "main"
+          requested_packages = {"typescript", "python"}
+          ts_bump = "patch"
+          py_bump = "patch"
+          reason = ""
+
+          if event_name == "repository_dispatch":
+              with Path(os.environ["EVENT_PATH"]).open("r", encoding="utf-8") as fh:
+                  payload = json.load(fh).get("client_payload", {})
+              requested_sha = str(payload.get("tidas_tools_sha", "") or "")
+              requested_ref = str(payload.get("tidas_tools_ref", "main") or "main")
+              packages = payload.get("packages", ["typescript", "python"])
+              if isinstance(packages, str):
+                  packages = [packages]
+              requested_packages = set(packages)
+              ts_bump = str(payload.get("typescript_bump", "patch") or "patch")
+              py_bump = str(payload.get("python_bump", "patch") or "patch")
+              reason = str(payload.get("reason", "") or "")
+          else:
+              requested_sha = os.environ.get("INPUT_TIDAS_TOOLS_SHA", "")
+              requested_ref = requested_sha or "main"
+              packages = os.environ.get("INPUT_PACKAGES", "both")
+              if packages == "typescript":
+                  requested_packages = {"typescript"}
+              elif packages == "python":
+                  requested_packages = {"python"}
+              else:
+                  requested_packages = {"typescript", "python"}
+              ts_bump = os.environ.get("INPUT_TYPESCRIPT_BUMP", "patch") or "patch"
+              py_bump = os.environ.get("INPUT_PYTHON_BUMP", "patch") or "patch"
+              reason = os.environ.get("INPUT_REASON", "") or ""
+
+          requested_typescript = "typescript" in requested_packages
+          requested_python = "python" in requested_packages
+
+          with outputs_path.open("a", encoding="utf-8") as fh:
+              fh.write(f"requested_sha={requested_sha}\n")
+              fh.write(f"requested_ref={requested_ref}\n")
+              fh.write(f"requested_typescript={'true' if requested_typescript else 'false'}\n")
+              fh.write(f"requested_python={'true' if requested_python else 'false'}\n")
+              fh.write(f"typescript_bump={ts_bump}\n")
+              fh.write(f"python_bump={py_bump}\n")
+              fh.write("reason<<EOF\n")
+              fh.write(f"{reason}\n")
+              fh.write("EOF\n")
+          PY
+
+      - name: Clone upstream tidas-tools
+        id: upstream
+        env:
+          REQUESTED_SHA: ${{ steps.request.outputs.requested_sha }}
+          REQUESTED_REF: ${{ steps.request.outputs.requested_ref }}
+        run: |
+          set -euo pipefail
+
+          UPSTREAM_DIR="$RUNNER_TEMP/tidas-tools-upstream"
+          CLONE_URL="https://x-access-token:${AUTOMATION_TOKEN}@github.com/tiangong-lca/tidas-tools.git"
+
+          rm -rf "$UPSTREAM_DIR"
+          git clone --quiet "$CLONE_URL" "$UPSTREAM_DIR"
+
+          if [ -n "$REQUESTED_SHA" ]; then
+            git -C "$UPSTREAM_DIR" checkout --detach "$REQUESTED_SHA"
+          else
+            git -C "$UPSTREAM_DIR" checkout --detach "$REQUESTED_REF"
+          fi
+
+          RESOLVED_SHA="$(git -C "$UPSTREAM_DIR" rev-parse HEAD)"
+          SHORT_SHA="${RESOLVED_SHA:0:7}"
+
+          {
+            echo "path=$UPSTREAM_DIR"
+            echo "resolved_sha=$RESOLVED_SHA"
+            echo "short_sha=$SHORT_SHA"
+            echo "branch_name=automation/tidas-tools-sync-$SHORT_SHA"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Set up Node.js
+        if: steps.request.outputs.requested_typescript == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.14.0
+          cache: npm
+          cache-dependency-path: sdks/typescript/package-lock.json
+
+      - name: Upgrade npm for release parity
+        if: steps.request.outputs.requested_typescript == 'true'
+        run: npm install --global npm@11.5.1
+
+      - name: Set up Python
+        if: steps.request.outputs.requested_python == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        if: steps.request.outputs.requested_python == 'true'
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Regenerate TypeScript SDK
+        if: steps.request.outputs.requested_typescript == 'true'
+        env:
+          TIDAS_TOOLS_SOURCE_MODE: auto
+          TIDAS_TOOLS_PATH: ${{ steps.upstream.outputs.path }}
+        run: ./scripts/ci/generate-typescript-sdk.sh
+
+      - name: Regenerate Python SDK
+        if: steps.request.outputs.requested_python == 'true'
+        env:
+          TIDAS_TOOLS_SOURCE_MODE: auto
+          TIDAS_TOOLS_PATH: ${{ steps.upstream.outputs.path }}
+        run: ./scripts/ci/generate-python-sdk.sh
+
+      - name: Detect changed packages
+        id: changes
+        run: |
+          set -euo pipefail
+
+          package_changed() {
+            local target="$1"
+            if [ -n "$(git status --porcelain -- "$target")" ]; then
+              echo "true"
+            else
+              echo "false"
+            fi
+          }
+
+          TS_CHANGED="$(package_changed sdks/typescript)"
+          PY_CHANGED="$(package_changed sdks/python)"
+
+          {
+            echo "typescript_changed=$TS_CHANGED"
+            echo "python_changed=$PY_CHANGED"
+          } >> "$GITHUB_OUTPUT"
+
+          if [ "$TS_CHANGED" = "true" ] || [ "$PY_CHANGED" = "true" ]; then
+            echo "any_changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "any_changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Stop when generated output is unchanged
+        if: steps.changes.outputs.any_changed != 'true'
+        env:
+          UPSTREAM_SHA: ${{ steps.upstream.outputs.resolved_sha }}
+        run: echo "No SDK artifacts changed for upstream $UPSTREAM_SHA."
+
+      - name: Bump TypeScript package version
+        if: steps.changes.outputs.typescript_changed == 'true'
+        env:
+          TYPESCRIPT_BUMP: ${{ steps.request.outputs.typescript_bump }}
+        run: npm run release:prepare:${TYPESCRIPT_BUMP}:typescript
+
+      - name: Bump Python package version
+        if: steps.changes.outputs.python_changed == 'true'
+        env:
+          PYTHON_BUMP: ${{ steps.request.outputs.python_bump }}
+        run: python3 ./scripts/ci/bump-python-version.py "$PYTHON_BUMP"
+
+      - name: Verify TypeScript package
+        if: steps.changes.outputs.typescript_changed == 'true'
+        env:
+          TIDAS_TOOLS_SOURCE_MODE: auto
+          TIDAS_TOOLS_PATH: ${{ steps.upstream.outputs.path }}
+        run: ./scripts/ci/verify-typescript-package.sh
+
+      - name: Verify Python package
+        if: steps.changes.outputs.python_changed == 'true'
+        env:
+          TIDAS_TOOLS_SOURCE_MODE: auto
+          TIDAS_TOOLS_PATH: ${{ steps.upstream.outputs.path }}
+        run: ./scripts/ci/verify-python-package.sh
+
+      - name: Collect release metadata
+        if: steps.changes.outputs.any_changed == 'true'
+        id: metadata
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import re
+          from pathlib import Path
+
+          outputs_path = Path(os.environ["GITHUB_OUTPUT"])
+          ts_version = json.loads(Path("sdks/typescript/package.json").read_text(encoding="utf-8"))["version"]
+          pyproject = Path("sdks/python/pyproject.toml").read_text(encoding="utf-8")
+          match = re.search(r'(?m)^version = "(?P<version>\d+\.\d+\.\d+)"$', pyproject)
+          if match is None:
+              raise SystemExit("error: could not locate Python package version")
+          py_version = match.group("version")
+
+          with outputs_path.open("a", encoding="utf-8") as fh:
+              fh.write(f"typescript_version={ts_version}\n")
+              fh.write(f"python_version={py_version}\n")
+          PY
+
+      - name: Compose pull request body
+        if: steps.changes.outputs.any_changed == 'true'
+        id: pr_body
+        env:
+          UPSTREAM_SHA: ${{ steps.upstream.outputs.resolved_sha }}
+          REQUEST_REASON: ${{ steps.request.outputs.reason }}
+          TYPESCRIPT_CHANGED: ${{ steps.changes.outputs.typescript_changed }}
+          PYTHON_CHANGED: ${{ steps.changes.outputs.python_changed }}
+          TYPESCRIPT_VERSION: ${{ steps.metadata.outputs.typescript_version }}
+          PYTHON_VERSION: ${{ steps.metadata.outputs.python_version }}
+          TYPESCRIPT_BUMP: ${{ steps.request.outputs.typescript_bump }}
+          PYTHON_BUMP: ${{ steps.request.outputs.python_bump }}
+        run: |
+          {
+            echo "body<<'EOF'"
+            echo "## Summary"
+            echo
+            echo "- Sync generated SDK artifacts from \`tiangong-lca/tidas-tools\` commit \`$UPSTREAM_SHA\`."
+            if [ "$TYPESCRIPT_CHANGED" = "true" ]; then
+              echo "- Release TypeScript package \`@tiangong-lca/tidas-sdk\` as \`$TYPESCRIPT_VERSION\` (\`$TYPESCRIPT_BUMP\` bump)."
+            fi
+            if [ "$PYTHON_CHANGED" = "true" ]; then
+              echo "- Release Python package \`tidas-sdk\` as \`$PYTHON_VERSION\` (\`$PYTHON_BUMP\` bump)."
+            fi
+            if [ -n "$REQUEST_REASON" ]; then
+              echo
+              echo "## Trigger reason"
+              echo
+              echo "$REQUEST_REASON"
+            fi
+            echo
+            echo "## Validation"
+            echo
+            if [ "$TYPESCRIPT_CHANGED" = "true" ]; then
+              echo "- \`./scripts/ci/verify-typescript-package.sh\`"
+            fi
+            if [ "$PYTHON_CHANGED" = "true" ]; then
+              echo "- \`./scripts/ci/verify-python-package.sh\`"
+            fi
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create or update release-prep pull request
+        if: steps.changes.outputs.any_changed == 'true'
+        id: create_pr
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.TIDAS_RELEASE_AUTOMATION_TOKEN }}
+          add-paths: |
+            sdks/typescript
+            sdks/python
+          branch: ${{ steps.upstream.outputs.branch_name }}
+          base: main
+          delete-branch: false
+          commit-message: "chore: sync SDKs from tidas-tools ${{ steps.upstream.outputs.short_sha }}"
+          title: "chore: sync SDKs from tidas-tools ${{ steps.upstream.outputs.short_sha }}"
+          body: ${{ steps.pr_body.outputs.body }}
+          author: "tidas-sdk automation <actions@github.com>"
+          committer: "tidas-sdk automation <actions@github.com>"
+
+      - name: Report pull request
+        if: steps.changes.outputs.any_changed == 'true'
+        run: |
+          echo "Pull request number: ${{ steps.create_pr.outputs.pull-request-number }}"
+          echo "Pull request URL: ${{ steps.create_pr.outputs.pull-request-url }}"

--- a/.github/workflows/tag-release-from-merge.yml
+++ b/.github/workflows/tag-release-from-merge.yml
@@ -1,0 +1,74 @@
+name: Tag Release From Merge
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  tag-release:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.TIDAS_RELEASE_AUTOMATION_TOKEN }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate automation token
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "error: missing TIDAS_RELEASE_AUTOMATION_TOKEN secret" >&2
+            exit 1
+          fi
+
+      - name: Detect release version changes
+        id: release
+        env:
+          BASE_REF: ${{ github.event.before }}
+          HEAD_REF: ${{ github.sha }}
+        run: |
+          python3 ./scripts/ci/detect-release-changes.py \
+            --base-ref "$BASE_REF" \
+            --head-ref "$HEAD_REF"
+
+      - name: Stop when no package version changed
+        if: steps.release.outputs.any_changed != 'true'
+        run: echo "No package version changes detected on main."
+
+      - name: Create TypeScript release tag
+        if: steps.release.outputs.typescript_changed == 'true'
+        env:
+          TAG_NAME: ${{ steps.release.outputs.typescript_tag }}
+          TARGET_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG_NAME}" >/dev/null 2>&1; then
+            echo "error: tag ${TAG_NAME} already exists" >&2
+            exit 1
+          fi
+          gh api "repos/${GITHUB_REPOSITORY}/git/refs" \
+            --method POST \
+            -f ref="refs/tags/${TAG_NAME}" \
+            -f sha="${TARGET_SHA}"
+
+      - name: Create Python release tag
+        if: steps.release.outputs.python_changed == 'true'
+        env:
+          TAG_NAME: ${{ steps.release.outputs.python_tag }}
+          TARGET_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG_NAME}" >/dev/null 2>&1; then
+            echo "error: tag ${TAG_NAME} already exists" >&2
+            exit 1
+          fi
+          gh api "repos/${GITHUB_REPOSITORY}/git/refs" \
+            --method POST \
+            -f ref="refs/tags/${TAG_NAME}" \
+            -f sha="${TARGET_SHA}"

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ docs/
 !docs/
 docs/*
 !docs/release-setup.md
+!docs/upstream-automation.md
 CLAUDE.md
 
 # kiro

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,8 @@ This repository publishes two independently versioned packages:
 
 - Start all new repo work from the latest `origin/main` unless the work is intentionally stacked on another branch.
 - Use a dedicated issue branch such as `feature/issue-<id>` or `chore/issue-<id>`.
-- Keep package release prep in a normal PR. Do not let GitHub Actions modify versions or push commits back to the repository.
+- Keep human-managed package release prep in a normal PR.
+- The upstream sync automation may push automation branches and open release-prep PRs when `tiangong-lca/tidas-tools` changes.
 - If this repo change is consumed by `lca-workspace`, complete the later submodule bump before treating the parent delivery as fully done.
 
 ## Release Model
@@ -24,11 +25,12 @@ Normal releases follow this path:
    - package docs if install or API guidance changed
 3. Let CI validate the package with the same commands used by release automation.
 4. Merge the PR.
-5. Create a tag on the merged commit:
+5. Let the repository automation create a tag on the merged commit:
    - TypeScript: `typescript-vX.Y.Z`
    - Python: `python-vX.Y.Z`
 6. GitHub Actions publishes from that immutable tagged commit after the protected release environment is approved.
-7. Verify the published package, create or update the GitHub Release note if needed, and close out the tracked issue / PR state.
+7. If the auto-tagging workflow is unavailable, a maintainer may create the matching tag manually as a fallback.
+8. Verify the published package, create or update the GitHub Release note if needed, and close out the tracked issue / PR state.
 
 Releases are package-specific. Do not force the TypeScript and Python packages to share a version number or a release date.
 
@@ -38,6 +40,13 @@ Repository workflows live under `.github/workflows/`:
 
 - `ci.yml`
   - validates package build, tests, generated artifacts, and packability on pull requests and `main`
+- `sync-from-tidas-tools.yml`
+  - regenerates SDK artifacts from an exact upstream `tiangong-lca/tidas-tools` commit
+  - bumps only affected package versions
+  - opens or updates a release-prep PR on an automation branch
+- `tag-release-from-merge.yml`
+  - watches pushes to `main`
+  - creates package tags when a merged commit changes package versions
 - `publish.yml`
   - publishes only from package tags
   - refuses to publish if the tag does not match the package version in source control
@@ -57,6 +66,8 @@ The publish workflow expects two GitHub environments:
 - `pypi-release`
 
 Both environments should require reviewer approval and should not allow self-review. The one-time registry and repository setup lives in `docs/release-setup.md`.
+
+Automation that pushes branches, opens PRs, or creates tags also requires the repository secret `TIDAS_RELEASE_AUTOMATION_TOKEN`.
 
 ## Local Validation
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ tidas-sdk/
 
 - **Repository Workflow**: [AGENTS.md](./AGENTS.md)
 - **Release Setup**: [docs/release-setup.md](./docs/release-setup.md)
+- **Upstream Automation Design**: [docs/upstream-automation.md](./docs/upstream-automation.md)
 - **TypeScript Release Guide**: [sdks/typescript/RELEASE.md](./sdks/typescript/RELEASE.md)
 - **Python Release Guide**: [sdks/python/RELEASE.md](./sdks/python/RELEASE.md)
 
@@ -109,6 +110,8 @@ Normal releases are tag-driven and published by GitHub Actions:
 
 - TypeScript package: create `typescript-vX.Y.Z` on the merged release commit
 - Python package: create `python-vX.Y.Z` on the merged release commit
+
+If you want `tidas-tools` changes to automatically regenerate and release these packages, see [docs/upstream-automation.md](./docs/upstream-automation.md).
 
 Use these local verification commands before opening a release PR:
 

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -2,6 +2,50 @@
 
 This document captures the one-time repository and registry configuration required for the `tidas-sdk` release workflows.
 
+## Cross-Repository Automation
+
+If you want `tiangong-lca/tidas-tools` changes to automatically rebuild and release the SDK packages in this repository, use the architecture described in [upstream-automation.md](./upstream-automation.md).
+
+Recommended model:
+
+- `tidas-tools` detects SDK-relevant upstream changes
+- `tidas-tools` dispatches into `tiangong-lca/tidas-sdk`
+- `tidas-sdk` regenerates SDKs from the exact upstream SHA and opens a release-prep PR
+- after merge, `tidas-sdk` creates package tags
+- the existing `publish.yml` workflow publishes from those tags
+
+Current workflow files:
+
+- `.github/workflows/sync-from-tidas-tools.yml`
+- `.github/workflows/tag-release-from-merge.yml`
+- `.github/workflows/publish.yml`
+
+Important constraint:
+
+- if tag creation is automated, do not rely on the default workflow `GITHUB_TOKEN` for those tag pushes
+- use a GitHub App token or fine-grained PAT so the downstream tag-triggered publish workflow can run as expected
+
+Operational preference:
+
+- keep registry ownership and Trusted Publishing configuration in `tiangong-lca/tidas-sdk`
+- keep `publish.yml` as the formal package release entrypoint
+- automate PR creation and tag creation, not cross-repository direct publishing
+
+Required secrets:
+
+- in `tiangong-lca/tidas-sdk`: `TIDAS_RELEASE_AUTOMATION_TOKEN`
+- in `tiangong-lca/tidas-tools`: `TIDAS_SDK_AUTOMATION_TOKEN`
+
+The current workflows expect a token that can:
+
+- read `tiangong-lca/tidas-tools`
+- push automation branches to `tiangong-lca/tidas-sdk`
+- open PRs in `tiangong-lca/tidas-sdk`
+- create tag refs in `tiangong-lca/tidas-sdk`
+- create a repository dispatch event from `tiangong-lca/tidas-tools` into `tiangong-lca/tidas-sdk`
+
+If you prefer a GitHub App instead of a PAT, keep the same secret names but update the workflows to mint an installation token at runtime.
+
 ## GitHub Repository
 
 Create these protected environments in `tiangong-lca/tidas-sdk`:

--- a/docs/upstream-automation.md
+++ b/docs/upstream-automation.md
@@ -1,0 +1,255 @@
+# Upstream Automation Design
+
+This document describes the recommended cross-repository automation path for keeping `tidas-sdk` in sync with upstream changes from `tiangong-lca/tidas-tools`.
+
+This is a design document, not a statement that the repository already runs this automation today. The current production release path remains the existing tag-driven workflow until the automation workflows and repository settings are actually introduced.
+
+The goal is:
+
+1. `tidas-tools` changes in a way that affects generated SDK content.
+2. `tidas-sdk` regenerates the Python and TypeScript SDKs from the exact upstream commit.
+3. If generated output changes, `tidas-sdk` opens a release-prep PR.
+4. After the PR is merged, `tidas-sdk` creates package tags.
+5. Existing tag-driven release automation publishes the packages.
+
+## Design Principles
+
+- `tidas-sdk` remains the package-owning repository.
+- npm and PyPI publishing stay in `tidas-sdk/.github/workflows/publish.yml`.
+- `tidas-tools` should trigger sync, not publish packages directly.
+- Auto-generated code changes should still land through a normal PR for review and CI.
+- TypeScript and Python package versions stay independent.
+
+## Recommended Flow
+
+```text
+tidas-tools push/merge
+  -> detect SDK-relevant upstream change
+  -> repository_dispatch to tiangong-lca/tidas-sdk
+  -> tidas-sdk sync workflow regenerates SDKs from exact tidas-tools SHA
+  -> if no diff: stop
+  -> if diff: bump package versions, commit bot branch, open PR
+  -> merge PR
+  -> tidas-sdk post-merge workflow creates package tag(s)
+  -> publish.yml runs from package tag(s)
+  -> npm / PyPI release completes
+```
+
+## Why This Split
+
+This design keeps ownership aligned:
+
+- `tidas-tools` owns schemas, conversion logic, and the upstream trigger.
+- `tidas-sdk` owns generated artifacts, package versions, PR review, tags, and publishing.
+
+That avoids a fragile setup where one repository publishes another repository's packages or silently changes package metadata outside the owning repo.
+
+## Workflow Layout
+
+### 1. `tidas-tools`: upstream change detector
+
+Add a workflow in `tiangong-lca/tidas-tools` that runs on merges to `main` and filters for SDK-relevant paths.
+
+Recommended responsibilities:
+
+- decide whether the merged change should trigger SDK regeneration
+- determine which package families are affected:
+  - `typescript`
+  - `python`
+  - `both`
+- determine the default version bump:
+  - `patch`
+  - `minor`
+  - `major`
+- send a `repository_dispatch` event to `tiangong-lca/tidas-sdk`
+
+Recommended dispatch payload:
+
+```json
+{
+  "event_type": "tidas_tools_changed",
+  "client_payload": {
+    "tidas_tools_sha": "<merged commit sha>",
+    "tidas_tools_ref": "refs/heads/main",
+    "packages": ["typescript", "python"],
+    "typescript_bump": "patch",
+    "python_bump": "patch",
+    "reason": "schema update"
+  }
+}
+```
+
+Use `repository_dispatch` instead of `workflow_dispatch` so the sender does not need Actions write permission on the target repository.
+
+### 2. `tidas-sdk`: sync and release-prep PR
+
+Add a workflow in `tiangong-lca/tidas-sdk` that runs on:
+
+- `repository_dispatch` with type `tidas_tools_changed`
+- optional manual `workflow_dispatch` for recovery or re-run
+
+Current implementation file:
+
+- `.github/workflows/sync-from-tidas-tools.yml`
+
+Recommended responsibilities:
+
+1. check out `tidas-sdk`
+2. check out `tiangong-lca/tidas-tools` at `client_payload.tidas_tools_sha`
+3. regenerate SDKs with:
+   - `TIDAS_TOOLS_SOURCE_MODE=auto`
+   - `TIDAS_TOOLS_PATH=<checked out tools path>`
+4. run local parity checks:
+   - `./scripts/ci/verify-typescript-package.sh`
+   - `./scripts/ci/verify-python-package.sh`
+5. detect whether TypeScript and/or Python outputs changed
+6. bump only the affected package version(s)
+7. commit changes to a bot branch
+8. open or update a release-prep PR against `main`
+
+Recommended branch name:
+
+- `automation/tidas-tools-sync-<short-sha>`
+
+Recommended PR body content:
+
+- upstream `tidas-tools` commit SHA
+- affected packages
+- version bump choice
+- generation summary
+- verification commands used
+
+### 3. `tidas-sdk`: post-merge auto-tagging
+
+Add a workflow in `tiangong-lca/tidas-sdk` that runs after the automation PR merges to `main`.
+
+Current implementation file:
+
+- `.github/workflows/tag-release-from-merge.yml`
+
+Recommended responsibilities:
+
+1. inspect the merged commit
+2. detect which package version(s) changed compared with the previous `main` commit
+3. create release tag(s):
+   - `typescript-vX.Y.Z`
+   - `python-vX.Y.Z`
+4. push those tags
+
+Important constraint:
+
+If the repository still relies on tag pushes to trigger `publish.yml`, the tag push must be created with a GitHub App token or PAT. A tag created with the default workflow `GITHUB_TOKEN` may not trigger the downstream publish workflow as intended.
+
+### 4. `tidas-sdk`: existing publish workflow
+
+No architectural change is required for:
+
+- `.github/workflows/publish.yml`
+
+That workflow should remain the package publishing entrypoint because npm and PyPI Trusted Publishing both bind to the concrete repository workflow identity.
+
+## Required GitHub Configuration
+
+### Authentication
+
+Use one shared GitHub App installed on both repositories, or a tightly scoped fine-grained PAT if an App is not available yet.
+
+GitHub App is preferred because it is easier to audit and rotate.
+
+Recommended permissions:
+
+- `Contents: Read and write`
+- `Pull requests: Read and write`
+- `Metadata: Read`
+
+If you choose `workflow_dispatch` instead of `repository_dispatch`, also grant:
+
+- `Actions: Read and write`
+
+### Secrets
+
+In `tidas-tools`:
+
+- `TIDAS_SDK_AUTOMATION_TOKEN`
+  - fine-grained PAT today, or a future GitHub App installation token minted at runtime
+  - must be able to dispatch into `tiangong-lca/tidas-sdk`
+
+In `tidas-sdk`:
+
+- `TIDAS_RELEASE_AUTOMATION_TOKEN`
+  - fine-grained PAT today, or a future GitHub App installation token minted at runtime
+  - must be able to push automation branches, open PRs, and create release tags
+
+If the same GitHub App is used in both repositories, the workflows can mint installation tokens at runtime instead of storing long-lived PATs.
+
+### Environments and registries
+
+Keep the existing environments:
+
+- `npm-release`
+- `pypi-release`
+
+Keep Trusted Publishing bound to:
+
+- repository: `tiangong-lca/tidas-sdk`
+- workflow: `.github/workflows/publish.yml`
+
+If fully unattended publishing is desired, update environment protection rules and trusted publisher expectations deliberately. Otherwise keep release approvals in place and automate only up to tag creation.
+
+## Version Bump Policy
+
+Recommended default policy:
+
+- schema-compatible additive change: `minor`
+- generator-only fix with no API break: `patch`
+- breaking schema or generated API change: `major`
+
+Implementation options:
+
+- simple mode: `tidas-tools` dispatch payload explicitly includes bump levels
+- managed mode: `tidas-tools` labels PRs and the workflow maps labels to bump levels
+- conservative mode: default to `patch` and let reviewers adjust the release-prep PR before merge
+
+For the first implementation, conservative mode is the safest.
+
+## Change Detection Rules
+
+Recommended behavior inside the `tidas-sdk` sync workflow:
+
+- if no generated output changes, do not open a PR
+- if only TypeScript files changed, bump and release only TypeScript
+- if only Python files changed, bump and release only Python
+- if both changed, prepare both releases in one PR but create independent tags after merge
+
+Do not force both packages to release together when only one generated surface changed.
+
+## Failure Handling
+
+Recommended safeguards:
+
+- if generation fails, fail the workflow and leave logs in the workflow run
+- if verification fails, fail before opening a PR
+- if a matching automation PR already exists for the same upstream SHA, update it instead of opening duplicates
+- if release tags already exist, fail fast instead of force-pushing or retagging
+- if publishing fails after tag creation, recover through the normal tag-based release process instead of rewriting history
+
+## Minimal Rollout Plan
+
+Implement in this order:
+
+1. add the `tidas-sdk` sync workflow with manual `workflow_dispatch` only
+2. validate branch push, PR creation, generation, and diff detection
+3. add post-merge auto-tagging in `tidas-sdk`
+4. confirm tags created by the chosen token successfully trigger `publish.yml`
+5. add `tidas-tools` automatic dispatch on merge to `main`
+
+This sequence reduces risk because `tidas-sdk` can be proven end to end before `tidas-tools` starts triggering it automatically.
+
+## Non-Goals
+
+This design does not recommend:
+
+- publishing `tidas-sdk` packages directly from `tidas-tools`
+- bypassing PR review for generated artifact changes
+- replacing `publish.yml` with a reusable workflow
+- coupling Python and TypeScript to one mandatory shared version number

--- a/scripts/ci/bump-python-version.py
+++ b/scripts/ci/bump-python-version.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+VERSION_PATTERN = re.compile(r'(?m)^version = "(?P<version>\d+\.\d+\.\d+)"$')
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Bump the Python SDK version in sdks/python/pyproject.toml."
+    )
+    parser.add_argument(
+        "part",
+        choices=("major", "minor", "patch"),
+        help="Semantic version segment to increment.",
+    )
+    parser.add_argument(
+        "--file",
+        type=Path,
+        default=Path(__file__).resolve().parents[2] / "sdks/python/pyproject.toml",
+        help="Path to the pyproject.toml file to update.",
+    )
+    return parser.parse_args()
+
+
+def bump_version(version: str, part: str) -> str:
+    major, minor, patch = (int(piece) for piece in version.split("."))
+    if part == "major":
+        return f"{major + 1}.0.0"
+    if part == "minor":
+        return f"{major}.{minor + 1}.0"
+    return f"{major}.{minor}.{patch + 1}"
+
+
+def main() -> int:
+    args = parse_args()
+    content = args.file.read_text(encoding="utf-8")
+    match = VERSION_PATTERN.search(content)
+    if match is None:
+        raise SystemExit(f"error: could not find a version entry in {args.file}")
+
+    current_version = match.group("version")
+    next_version = bump_version(current_version, args.part)
+    updated = VERSION_PATTERN.sub(f'version = "{next_version}"', content, count=1)
+    args.file.write_text(updated, encoding="utf-8")
+    print(next_version)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/detect-release-changes.py
+++ b/scripts/ci/detect-release-changes.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+from typing import Callable
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TYPESCRIPT_PACKAGE = Path("sdks/typescript/package.json")
+PYTHON_PACKAGE = Path("sdks/python/pyproject.toml")
+ZERO_SHA = "0" * 40
+PYTHON_VERSION_PATTERN = re.compile(r'(?m)^version = "(?P<version>\d+\.\d+\.\d+)"$')
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Detect package version changes between two git refs."
+    )
+    parser.add_argument("--base-ref", required=True, help="Base git ref to compare from.")
+    parser.add_argument(
+        "--head-ref",
+        default="HEAD",
+        help="Head git ref to compare to. Defaults to HEAD.",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=REPO_ROOT,
+        help="Repository root for git commands.",
+    )
+    parser.add_argument(
+        "--github-output",
+        default=os.environ.get("GITHUB_OUTPUT", ""),
+        help="Optional GitHub Actions output file.",
+    )
+    return parser.parse_args()
+
+
+def load_ref_file(repo_root: Path, ref: str, relative_path: Path) -> str | None:
+    if not ref or ref == ZERO_SHA:
+        return None
+
+    command = ["git", "-C", str(repo_root), "show", f"{ref}:{relative_path.as_posix()}"]
+    result = subprocess.run(command, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        return None
+    return result.stdout
+
+
+def parse_typescript_version(raw: str) -> str:
+    return json.loads(raw)["version"]
+
+
+def parse_python_version(raw: str) -> str:
+    match = PYTHON_VERSION_PATTERN.search(raw)
+    if match is None:
+        raise ValueError("could not locate Python package version")
+    return match.group("version")
+
+
+def build_outputs(
+    repo_root: Path,
+    base_ref: str,
+    head_ref: str,
+) -> dict[str, str]:
+    definitions: list[tuple[str, Path, Callable[[str], str], str]] = [
+        ("typescript", TYPESCRIPT_PACKAGE, parse_typescript_version, "typescript-v"),
+        ("python", PYTHON_PACKAGE, parse_python_version, "python-v"),
+    ]
+
+    outputs: dict[str, str] = {}
+    any_changed = False
+
+    for name, relative_path, parser, tag_prefix in definitions:
+        base_raw = load_ref_file(repo_root, base_ref, relative_path)
+        head_raw = load_ref_file(repo_root, head_ref, relative_path)
+
+        base_version = parser(base_raw) if base_raw is not None else ""
+        head_version = parser(head_raw) if head_raw is not None else ""
+        changed = bool(base_version and head_version and base_version != head_version)
+
+        outputs[f"{name}_previous_version"] = base_version
+        outputs[f"{name}_version"] = head_version
+        outputs[f"{name}_changed"] = "true" if changed else "false"
+        outputs[f"{name}_tag"] = f"{tag_prefix}{head_version}" if changed else ""
+        any_changed = any_changed or changed
+
+    outputs["any_changed"] = "true" if any_changed else "false"
+    return outputs
+
+
+def write_outputs(outputs: dict[str, str], github_output: str) -> None:
+    lines = [f"{key}={value}" for key, value in outputs.items()]
+    if github_output:
+        with Path(github_output).open("a", encoding="utf-8") as fh:
+            for line in lines:
+                fh.write(f"{line}\n")
+    else:
+        for line in lines:
+            print(line)
+
+
+def main() -> int:
+    args = parse_args()
+    outputs = build_outputs(
+        repo_root=args.repo_root.resolve(),
+        base_ref=args.base_ref,
+        head_ref=args.head_ref,
+    )
+    write_outputs(outputs, args.github_output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #9

## Summary
- add a sync workflow that rebuilds SDK artifacts from an exact `tiangong-lca/tidas-tools` SHA and opens a release-prep PR
- add a post-merge tagging workflow plus helper scripts so the existing tag-driven publish flow can stay in place
- document the automation design, required secrets, and updated release rules

## Validation
- `python3 -m py_compile scripts/ci/bump-python-version.py scripts/ci/detect-release-changes.py`
- `python3 scripts/ci/detect-release-changes.py --base-ref HEAD --head-ref HEAD`
- workflow YAML parse check via Ruby `YAML.load_file`
- `git diff --check`

## Notes
- this PR assumes `TIDAS_RELEASE_AUTOMATION_TOKEN` will be configured before the workflows are relied on
- automatic tag creation is designed to preserve `.github/workflows/publish.yml` as the publishing entrypoint
