### PR TITLE
fix: harden TypeScript UUID generation

### DIFF
--- a/sdks/typescript/README-zh.md
+++ b/sdks/typescript/README-zh.md
@@ -225,8 +225,10 @@ clonedContact.contactDataSet.contactInformation.dataSetInformation['common:name'
   { '@xml:lang': 'zh', '#text': '张博士（副本）' }
 ];
 
+// 如需手动生成 UUID，可先从 @tiangong-lca/tidas-sdk/utils 引入 randomUUID
+
 // 为克隆体生成新的 UUID
-clonedContact.contactDataSet.contactInformation.dataSetInformation['common:UUID'] = crypto.randomUUID();
+clonedContact.contactDataSet.contactInformation.dataSetInformation['common:UUID'] = randomUUID();
 ```
 
 ### 7. 实体关系

--- a/sdks/typescript/examples/02-advanced-features/advanced-usage-patterns.ts
+++ b/sdks/typescript/examples/02-advanced-features/advanced-usage-patterns.ts
@@ -23,6 +23,7 @@ import {
 } from '@tiangong-lca/tidas-sdk/core';
 
 import { Contact, Flow, Process } from '@tiangong-lca/tidas-sdk/types';
+import { randomUUID } from '@tiangong-lca/tidas-sdk/utils';
 
 // Example 1: Batch Entity Creation
 console.log('=== Example 1: Batch Entity Creation ===');
@@ -220,7 +221,7 @@ clonedContact.contactDataSet.contactInformation.dataSetInformation[
 // Generate new UUID for the clone
 clonedContact.contactDataSet.contactInformation.dataSetInformation[
   'common:UUID'
-] = crypto.randomUUID();
+] = randomUUID();
 
 const originalContactName =
   originalContact.contactDataSet.contactInformation.dataSetInformation[

--- a/sdks/typescript/src/core/entities/TidasContact.ts
+++ b/sdks/typescript/src/core/entities/TidasContact.ts
@@ -3,6 +3,7 @@ import { ContactSchema } from '../../schemas';
 import { Contact } from '../../types';
 import { ValidationConfig } from '../config/ValidationConfig';
 import { MultiLangArray } from '../../types/multi-lang-types';
+import { randomUUID } from '../../utils/uuid';
 
 /**
  * TIDAS Contact entity - simplified pure data container
@@ -64,7 +65,7 @@ export class TidasContact extends TidasEntity<Contact> {
     ) {
       this.setNestedValue(
         'contactDataSet.contactInformation.dataSetInformation.common:UUID',
-        crypto.randomUUID()
+        randomUUID()
       );
     }
 

--- a/sdks/typescript/src/core/entities/TidasFlow.ts
+++ b/sdks/typescript/src/core/entities/TidasFlow.ts
@@ -9,6 +9,7 @@ import {
   joinTexts,
   pickShortDescription,
 } from '../../utils/markdown';
+import { randomUUID } from '../../utils/uuid';
 
 /**
  * TIDAS Flow entity - pure data container
@@ -71,7 +72,7 @@ export class TidasFlow extends TidasEntity<Flow> {
     ) {
       this.setNestedValue(
         'flowDataSet.flowInformation.dataSetInformation.common:UUID',
-        crypto.randomUUID()
+        randomUUID()
       );
     }
 

--- a/sdks/typescript/src/core/entities/TidasFlowProperty.ts
+++ b/sdks/typescript/src/core/entities/TidasFlowProperty.ts
@@ -3,6 +3,7 @@ import { FlowPropertySchema } from '../../schemas';
 import { FlowProperty } from '../../types';
 import { ValidationConfig } from '../config/ValidationConfig';
 import { MultiLangArray } from '../../types/multi-lang-types';
+import { randomUUID } from '../../utils/uuid';
 
 /**
  * TIDAS FlowProperty entity - pure data container
@@ -67,7 +68,7 @@ export class TidasFlowProperty extends TidasEntity<FlowProperty> {
     ) {
       this.setNestedValue(
         'flowPropertyDataSet.flowPropertiesInformation.dataSetInformation.common:UUID',
-        crypto.randomUUID()
+        randomUUID()
       );
     }
 

--- a/sdks/typescript/src/core/entities/TidasLCIAMethod.ts
+++ b/sdks/typescript/src/core/entities/TidasLCIAMethod.ts
@@ -3,6 +3,7 @@ import { LCIAMethodSchema } from '../../schemas';
 import { LCIAMethod } from '../../types';
 import { ValidationConfig } from '../config/ValidationConfig';
 import { MultiLangArray } from '../../types/multi-lang-types';
+import { randomUUID } from '../../utils/uuid';
 
 /**
  * TIDAS LCIAMethod entity - pure data container
@@ -68,7 +69,7 @@ export class TidasLCIAMethod extends TidasEntity<LCIAMethod> {
     ) {
       this.setNestedValue(
         'LCIAMethodDataSet.LCIAMethodInformation.dataSetInformation.common:UUID',
-        crypto.randomUUID()
+        randomUUID()
       );
     }
 

--- a/sdks/typescript/src/core/entities/TidasLifeCycleModel.ts
+++ b/sdks/typescript/src/core/entities/TidasLifeCycleModel.ts
@@ -9,6 +9,7 @@ import {
   joinTexts,
   pickShortDescription,
 } from '../../utils/markdown';
+import { randomUUID } from '../../utils/uuid';
 
 /**
  * TIDAS LifeCycleModel entity - pure data container
@@ -74,7 +75,7 @@ export class TidasLifeCycleModel extends TidasEntity<LifeCycleModel> {
     ) {
       this.setNestedValue(
         'lifeCycleModelDataSet.lifeCycleModelInformation.dataSetInformation.common:UUID',
-        crypto.randomUUID()
+        randomUUID()
       );
     }
 

--- a/sdks/typescript/src/core/entities/TidasProcess.ts
+++ b/sdks/typescript/src/core/entities/TidasProcess.ts
@@ -9,6 +9,7 @@ import {
   joinTexts,
   pickShortDescription,
 } from '../../utils/markdown';
+import { randomUUID } from '../../utils/uuid';
 
 /**
  * TIDAS Process entity - pure data container
@@ -80,7 +81,7 @@ export class TidasProcess extends TidasEntity<Process> {
     ) {
       this.setNestedValue(
         'processDataSet.processInformation.dataSetInformation.common:UUID',
-        crypto.randomUUID()
+        randomUUID()
       );
     }
 

--- a/sdks/typescript/src/core/entities/TidasSource.ts
+++ b/sdks/typescript/src/core/entities/TidasSource.ts
@@ -3,6 +3,7 @@ import { SourceSchema } from '../../schemas';
 import { Source } from '../../types';
 import { ValidationConfig } from '../config/ValidationConfig';
 import { MultiLangArray } from '../../types/multi-lang-types';
+import { randomUUID } from '../../utils/uuid';
 
 /**
  * TIDAS Source entity - pure data container
@@ -64,7 +65,7 @@ export class TidasSource extends TidasEntity<Source> {
     ) {
       this.setNestedValue(
         'sourceDataSet.sourceInformation.dataSetInformation.common:UUID',
-        crypto.randomUUID()
+        randomUUID()
       );
     }
 

--- a/sdks/typescript/src/core/entities/TidasUnitGroup.ts
+++ b/sdks/typescript/src/core/entities/TidasUnitGroup.ts
@@ -3,6 +3,7 @@ import { UnitGroupSchema } from '../../schemas';
 import { UnitGroup } from '../../types';
 import { ValidationConfig } from '../config/ValidationConfig';
 import { MultiLangArray } from '../../types/multi-lang-types';
+import { randomUUID } from '../../utils/uuid';
 
 /**
  * TIDAS UnitGroup entity - pure data container
@@ -68,7 +69,7 @@ export class TidasUnitGroup extends TidasEntity<UnitGroup> {
     ) {
       this.setNestedValue(
         'unitGroupDataSet.unitGroupInformation.dataSetInformation.common:UUID',
-        crypto.randomUUID()
+        randomUUID()
       );
     }
 

--- a/sdks/typescript/src/core/entities/tidas_entity_uuid.test.ts
+++ b/sdks/typescript/src/core/entities/tidas_entity_uuid.test.ts
@@ -1,0 +1,25 @@
+import { TidasContact } from './TidasContact';
+import { TidasFlow } from './TidasFlow';
+
+const UUID_V4_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+describe('entity UUID defaults', () => {
+  it('generates UUIDs for entities without relying on direct global crypto access', () => {
+    const flow = new TidasFlow();
+    const contact = new TidasContact();
+
+    expect(
+      UUID_V4_PATTERN.test(
+        flow.flowDataSet.flowInformation.dataSetInformation['common:UUID']
+      )
+    ).toBe(true);
+    expect(
+      UUID_V4_PATTERN.test(
+        contact.contactDataSet.contactInformation.dataSetInformation[
+          'common:UUID'
+        ]
+      )
+    ).toBe(true);
+  });
+});

--- a/sdks/typescript/src/utils/index.ts
+++ b/sdks/typescript/src/utils/index.ts
@@ -6,6 +6,7 @@
 // Object manipulation utilities
 export * from './object-utils';
 export * from './markdown';
+export * from './uuid';
 
 // Re-export commonly used functions with cleaner names
 export { deepClone, merge, get, set, updatePath } from './object-utils';

--- a/sdks/typescript/src/utils/uuid.ts
+++ b/sdks/typescript/src/utils/uuid.ts
@@ -1,0 +1,41 @@
+const formatUuid = (bytes: Uint8Array): string => {
+  const normalized = bytes.slice();
+  normalized[6] = (normalized[6] & 0x0f) | 0x40;
+  normalized[8] = (normalized[8] & 0x3f) | 0x80;
+
+  const hex = Array.from(normalized, (byte) =>
+    byte.toString(16).padStart(2, '0')
+  );
+
+  return [
+    hex.slice(0, 4).join(''),
+    hex.slice(4, 6).join(''),
+    hex.slice(6, 8).join(''),
+    hex.slice(8, 10).join(''),
+    hex.slice(10, 16).join(''),
+  ].join('-');
+};
+
+const createFallbackBytes = (): Uint8Array => {
+  const bytes = new Uint8Array(16);
+
+  for (let index = 0; index < bytes.length; index += 1) {
+    bytes[index] = Math.floor(Math.random() * 256);
+  }
+
+  return bytes;
+};
+
+export const randomUUID = (): string => {
+  if (typeof globalThis.crypto?.randomUUID === 'function') {
+    return globalThis.crypto.randomUUID();
+  }
+
+  if (typeof globalThis.crypto?.getRandomValues === 'function') {
+    const bytes = new Uint8Array(16);
+    globalThis.crypto.getRandomValues(bytes);
+    return formatUuid(bytes);
+  }
+
+  return formatUuid(createFallbackBytes());
+};


### PR DESCRIPTION
Closes tiangong-lca/tidas-sdk#13

## Summary
- Replace direct entity UUID creation calls to crypto.randomUUID() with a shared TypeScript helper.
- Keep the synced legacy fix scoped to TypeScript UUID compatibility without carrying over unrelated release bump commits.
- Cover the helper-backed UUID path with a focused entity regression test and update docs/examples to use the shared utility.

## Key Decisions
- Use an in-repo UUID helper that prefers native crypto APIs and falls back to local UUID v4 formatting so the fix works with the current CommonJS package and Jest setup.

## Validation
- npm test -- --runInBand
- npm run typecheck
- npm run build

## Risks / Rollback
- Low risk: this only changes default UUID generation and example usage; generated UUIDs remain RFC 4122 v4-shaped.

## Follow-ups
- Handle any future TypeScript package version bump as a separate release-oriented change instead of mixing it into this compatibility fix.

## Workspace Integration
- Requires a later lca-workspace submodule bump if the workspace pins this repo.