### PR TITLE
chore: prepare Python SDK v0.1.8 release

### DIFF
--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tidas-sdk"
-version = "0.1.6"
+version = "0.1.8"
 description = "Python SDK for TIDAS/ILCD Life Cycle Assessment data"
 authors = [{ name = "Tiangong LCA Team" }]
 license = { text = "MIT" }


### PR DESCRIPTION
Closes tiangong-lca/tidas-sdk#15

## Summary
- Bump the Python SDK package version from 0.1.6 to 0.1.8 on top of the merged validation fixes now on main.
- Keep this release-prep change scoped to Python package metadata so the repository's tag-driven publish flow can cut a new PyPI release from the merged commit.

## Key Decisions
- Use 0.1.8 as the next patch release because PyPI already has 0.1.7 and the newly merged fixes need a fresh publishable version.

## Validation
- ./scripts/ci/verify-python-package.sh

## Risks / Rollback
- Low risk: release-prep change is limited to Python version metadata; verification passed on the release branch before PR creation.

## Follow-ups
- After merge, confirm either the auto-tag workflow creates python-v0.1.8 or create that tag manually if automation does not fire.

## Workspace Integration
- Requires a later lca-workspace submodule bump if the workspace pins this repo version for delivery.