### PR TITLE
feat: add TypeScript parity validation support

### DIFF
--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -15,6 +15,7 @@ TypeScript SDK for TIDAS (TianGong Life Cycle Assessment data format) providing 
 - ✅ **Property Access**: Convenient API for accessing nested properties
 - ✅ **Object Utilities**: Factory functions and manipulation utilities
 - ✅ **JSON Conversion**: Seamless serialization/deserialization
+- ✅ **tidas-tools Parity APIs**: Package-level validation compatibility
 
 ## 📦 Installation
 
@@ -31,8 +32,8 @@ import { createTidasContact, TidasContact } from '@tiangong-lca/tidas-sdk';
 
 // Create a contact using factory function
 const contact = createTidasContact({
-  name: "Example Organization",
-  email: "contact@example.com"
+  name: 'Example Organization',
+  email: 'contact@example.com',
 });
 
 // Access properties with type safety
@@ -45,16 +46,16 @@ const json = contact.toJSON();
 ### Advanced Usage
 
 ```typescript
-import { 
+import {
   TidasProcess,
   createTidasProcess,
-  validateTidasData
+  validateTidasData,
 } from '@tiangong-lca/tidas-sdk';
 
 // Create and validate complex objects
 const process = createTidasProcess({
-  name: "Manufacturing Process",
-  description: "Production of electronic components"
+  name: 'Manufacturing Process',
+  description: 'Production of electronic components',
 });
 
 // Validate data
@@ -64,13 +65,24 @@ if (!validation.success) {
 }
 ```
 
+### tidas-tools Parity APIs
+
+```typescript
+import { validatePackageDir } from '@tiangong-lca/tidas-sdk/parity';
+
+const report = validatePackageDir('/path/to/tidas-package');
+if (!report.ok) {
+  console.error(report.issues);
+}
+```
+
 ## 🏗️ Architecture
 
 ### Module Structure
 
 ```typescript
 // Core imports
-import { 
+import {
   // Types
   TidasContact,
   TidasProcess,
@@ -86,7 +98,7 @@ import {
   // Utilities
   validateTidasData,
   convertToJSON,
-  convertFromJSON
+  convertFromJSON,
 } from '@tiangong-lca/tidas-sdk';
 
 // Individual modules

--- a/sdks/typescript/examples/01-basic-usage/entities-usage.ts
+++ b/sdks/typescript/examples/01-basic-usage/entities-usage.ts
@@ -57,10 +57,7 @@ contact.contactDataSet.contactInformation.dataSetInformation.email =
 contact.contactDataSet.contactInformation.dataSetInformation.telefax =
   '+1-555-0123';
 
-console.log(
-  'Contact name:',
-  contact.contactDataSet.contactInformation.dataSetInformation['common:name']
-);
+console.log('Contact names:', { en: enName, fr: frName });
 console.log(
   'Contact validation:',
   contact.validate().success ? 'PASSED' : 'FAILED'

--- a/sdks/typescript/examples/02-advanced-features/advanced-usage-patterns.ts
+++ b/sdks/typescript/examples/02-advanced-features/advanced-usage-patterns.ts
@@ -11,18 +11,14 @@
 import {
   createContactsBatch,
   createFlowsBatch,
-  createProcessesBatch,
   createContact,
   createFlow,
   createProcess,
   createUnitGroup,
   createFlowProperty,
-  TidasContact,
-  TidasFlow,
-  TidasProcess,
 } from '@tiangong-lca/tidas-sdk/core';
 
-import { Contact, Flow, Process } from '@tiangong-lca/tidas-sdk/types';
+import { Contact } from '@tiangong-lca/tidas-sdk/types';
 import { randomUUID } from '@tiangong-lca/tidas-sdk/utils';
 
 // Example 1: Batch Entity Creation

--- a/sdks/typescript/examples/03-validation-modes/validation-test.ts
+++ b/sdks/typescript/examples/03-validation-modes/validation-test.ts
@@ -1,10 +1,11 @@
-import { createProcess,createContact } from '../../src/core/factories';
+import { createProcess, createContact } from '../../src/core/factories';
 
-const tidasData = createContact()
-console.log(tidasData.contactDataSet)
-tidasData.contactDataSet.administrativeInformation.publicationAndOwnership['common:dataSetVersion'] = '1.0.0'
-console.log(tidasData.contactDataSet)
-
+const tidasData = createContact();
+console.log(tidasData.contactDataSet);
+tidasData.contactDataSet.administrativeInformation.publicationAndOwnership[
+  'common:dataSetVersion'
+] = '1.0.0';
+console.log(tidasData.contactDataSet);
 
 const defaultProcess = createProcess();
 console.log(JSON.stringify(defaultProcess, null, 2));
@@ -374,6 +375,11 @@ const processJson = {
     },
   },
 };
+
+console.log(
+  'Sample process JSON version:',
+  processJson.processDataSet['@version']
+);
 
 defaultProcess.processDataSet.processInformation.dataSetInformation.classificationInformation =
   {

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -81,6 +81,7 @@
       "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -1858,6 +1859,7 @@
       "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.72.tgz",
       "integrity": "sha512-WsGWVZYnlKffj2eEfDocPNiaTRoxyYiLSQdQ7oxZvxGZBqo/90vpjbC33UGK1uPNBM4kT+pkdaol/MnvKUh8TQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
         "ansi-styles": "^5.0.0",
@@ -1940,6 +1942,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -1996,6 +1999,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -2361,6 +2365,7 @@
       "integrity": "sha512-4zXMWD91vBLGRtHK3YbIoFMia+1nqEz72coM42C5ETjnNCa/heoj7NT1G67iAfOqMmcfhuCZ4uNpyz8EjlAejw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.8.0"
       }
@@ -2437,6 +2442,7 @@
       "integrity": "sha512-FuYgkHwZLuPbZjQHzJXrtXreJdFMKl16BFYyRrLxDhWr6Qr7Kbcu2s1Yhu8tsiMXw1S0W1pjfFfYEt+R604s+Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.36.0",
         "@typescript-eslint/types": "8.36.0",
@@ -2929,6 +2935,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3248,6 +3255,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -3902,6 +3910,7 @@
       "integrity": "sha512-zmxXPNMOXmwm9E0yQLi5uqXHs7uq2UIiqEKo3Gq+3fwo1XrJ+hijAZImyF7hclW3E6oHz43Yk3RP8at6OTKflQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5080,6 +5089,7 @@
       "integrity": "sha512-9QE0RS4WwTj/TtTC4h/eFVmFAhGNVerSB9XpJh8sqaXlP73ILcPcZ7JWjjEtJJe2m8QyBLKKfPQuK+3F+Xij/g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.0.4",
         "@jest/types": "30.0.1",
@@ -7343,6 +7353,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7466,6 +7477,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -7642,6 +7654,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -29,6 +29,11 @@
       "types": "./dist/utils/index.d.ts",
       "import": "./dist/utils/index.js",
       "require": "./dist/utils/index.js"
+    },
+    "./parity": {
+      "types": "./dist/parity/index.d.ts",
+      "import": "./dist/parity/index.js",
+      "require": "./dist/parity/index.js"
     }
   },
   "scripts": {
@@ -83,8 +88,8 @@
     "jest": "^30.0.4",
     "prettier": "^3.6.2",
     "ts-jest": "^29.4.0",
-    "tsx": "^4.7.0",
     "ts-node": "^10.9.2",
+    "tsx": "^4.7.0",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.36.0"
   },

--- a/sdks/typescript/scripts/json-schema-to-typescript.ts
+++ b/sdks/typescript/scripts/json-schema-to-typescript.ts
@@ -65,24 +65,6 @@ class JsonSchemaToTypeScript {
     this.currentFile = currentFile;
     this.rootSchema = schema;
 
-    // --- 插入 MultiLangArray class 和 MultiLangItem type ---
-    // 检查 schema 是否包含 *MultiLang 类型
-    let needsMultiLangClass = false;
-    const scanForMultiLang = (obj: any) => {
-      if (!obj || typeof obj !== 'object') return;
-      if (
-        obj.title &&
-        typeof obj.title === 'string' &&
-        obj.title.endsWith('MultiLang')
-      ) {
-        needsMultiLangClass = true;
-      }
-      for (const v of Object.values(obj)) {
-        scanForMultiLang(v);
-      }
-    };
-    scanForMultiLang(schema);
-
     // Process $defs first if they exist
     if (schema.$defs) {
       for (const [defName, defSchema] of Object.entries(schema.$defs)) {
@@ -290,7 +272,7 @@ class JsonSchemaToTypeScript {
       ...(extension || {}),
     };
 
-    if ((base?.type === 'object') || (extension?.type === 'object')) {
+    if (base?.type === 'object' || extension?.type === 'object') {
       merged.type = 'object';
     }
 
@@ -304,7 +286,10 @@ class JsonSchemaToTypeScript {
     if (propertyNames.size > 0) {
       merged.properties = {};
       for (const propertyName of propertyNames) {
-        if (propertyName in baseProperties && propertyName in extensionProperties) {
+        if (
+          propertyName in baseProperties &&
+          propertyName in extensionProperties
+        ) {
           merged.properties[propertyName] = this.mergePropertySchema(
             baseProperties[propertyName],
             extensionProperties[propertyName]
@@ -708,7 +693,6 @@ class JsonSchemaToTypeScript {
         const escapedValue = constValue
           .replace(/\\/g, '\\\\') // Escape backslashes first
           .replace(/"/g, '\\"') // Escape double quotes
-          .replace(/'/g, "\\'") // Escape single quotes
           .replace(/\n/g, '\\n') // Escape newlines
           .replace(/\r/g, '\\r') // Escape carriage returns
           .replace(/\t/g, '\\t'); // Escape tabs
@@ -727,7 +711,6 @@ class JsonSchemaToTypeScript {
             const escapedValue = v
               .replace(/\\/g, '\\\\') // Escape backslashes first
               .replace(/"/g, '\\"') // Escape double quotes
-              .replace(/'/g, "\\'") // Escape single quotes
               .replace(/\n/g, '\\n') // Escape newlines
               .replace(/\r/g, '\\r') // Escape carriage returns
               .replace(/\t/g, '\\t'); // Escape tabs

--- a/sdks/typescript/src/core/entities/TidasFlow.ts
+++ b/sdks/typescript/src/core/entities/TidasFlow.ts
@@ -230,8 +230,10 @@ export class TidasFlow extends TidasEntity<Flow> {
     const version = this.dataSetVersion(dataset);
     if (version) lines.push(`**Version:** ${version}`);
 
-    const { name: refPropName, value: refPropValue } = this.referencePropertySummary(dataset, lang);
-    if (refPropName || refPropValue) lines.push(`**Reference Property:** ${refPropName ?? 'N/A'}`);
+    const { name: refPropName, value: refPropValue } =
+      this.referencePropertySummary(dataset, lang);
+    if (refPropName || refPropValue)
+      lines.push(`**Reference Property:** ${refPropName ?? 'N/A'}`);
     if (refPropValue) lines.push(`**Property Mean:** ${refPropValue}`);
 
     const method = this.methodology(dataset);
@@ -248,30 +250,40 @@ export class TidasFlow extends TidasEntity<Flow> {
 
     if (lines[lines.length - 1] !== '') lines.push('');
 
-    const description = joinTexts((dataInfo as any)?.['common:generalComment'], lang);
+    const description = joinTexts(
+      (dataInfo as any)?.['common:generalComment'],
+      lang
+    );
     if (description) lines.push('## Description', '', description, '');
 
-    const geography = this.geography(flowInfo, lang);
+    const geography = this.geography(flowInfo);
     if (geography) lines.push('## Geography', '', geography, '');
 
     const technology = this.technology(flowInfo, lang);
     if (technology) lines.push('## Technology', '', technology, '');
 
     const flowProps = this.flowProperties(dataset, lang);
-    if (flowProps.length) lines.push('## Flow Properties', '', ...flowProps, '');
+    if (flowProps.length)
+      lines.push('## Flow Properties', '', ...flowProps, '');
 
     if (lines[lines.length - 1] === '') lines.pop();
     return lines.join('\n');
   }
 
   private composeTitle(
-    dataInfo: Flow['flowDataSet']['flowInformation']['dataSetInformation'] | undefined,
+    dataInfo:
+      | Flow['flowDataSet']['flowInformation']['dataSetInformation']
+      | undefined,
     lang: string
   ): string {
     if (!dataInfo) return 'Flow';
     const nameObj = dataInfo.name;
     const parts: string[] = [];
-    for (const field of ['baseName', 'mixAndLocationTypes', 'treatmentStandardsRoutes'] as const) {
+    for (const field of [
+      'baseName',
+      'mixAndLocationTypes',
+      'treatmentStandardsRoutes',
+    ] as const) {
       const part = joinTexts((nameObj as any)?.[field], lang, ' | ');
       if (part) parts.push(part);
     }
@@ -282,11 +294,13 @@ export class TidasFlow extends TidasEntity<Flow> {
     dataset: Flow['flowDataSet'],
     lang: string
   ): { name?: string; value?: string } {
-    const refId = dataset?.flowInformation?.quantitativeReference?.referenceToReferenceFlowProperty;
+    const refId =
+      dataset?.flowInformation?.quantitativeReference
+        ?.referenceToReferenceFlowProperty;
     if (refId === undefined || refId === null) return {};
     const properties = ensureArray<any>(dataset?.flowProperties?.flowProperty);
     const refItem = properties.find(
-      item => String(item?.['@dataSetInternalID'] ?? '') === String(refId)
+      (item) => String(item?.['@dataSetInternalID'] ?? '') === String(refId)
     );
     if (!refItem) return {};
     const refInfo = (refItem as any).referenceToFlowPropertyDataSet;
@@ -295,14 +309,20 @@ export class TidasFlow extends TidasEntity<Flow> {
     return { name, value };
   }
 
-  private classificationPath(dataInfo: Flow['flowDataSet']['flowInformation']['dataSetInformation'] | undefined): string | undefined {
+  private classificationPath(
+    dataInfo:
+      | Flow['flowDataSet']['flowInformation']['dataSetInformation']
+      | undefined
+  ): string | undefined {
     if (!dataInfo?.classificationInformation) return undefined;
     const classification = dataInfo.classificationInformation as any;
     const container =
       classification['common:elementaryFlowCategorization'] ??
       classification['common:classification'] ??
       classification.commonClassification;
-    const categories = ensureArray<any>(container?.['common:category'] ?? container?.['common:class']);
+    const categories = ensureArray<any>(
+      container?.['common:category'] ?? container?.['common:class']
+    );
     if (!categories.length) return undefined;
     const sorted = categories.slice().sort((a, b) => {
       const aLevel = Number((a as any)['@level']);
@@ -312,27 +332,41 @@ export class TidasFlow extends TidasEntity<Flow> {
       if (Number.isNaN(bLevel)) return -1;
       return aLevel - bLevel;
     });
-    const parts = sorted.map(entry => String((entry as any)['#text'] ?? '')).filter(Boolean);
+    const parts = sorted
+      .map((entry) => String((entry as any)['#text'] ?? ''))
+      .filter(Boolean);
     return parts.length ? parts.join(' > ') : undefined;
   }
 
-  private dataSetVersion(dataset: Flow['flowDataSet'] | undefined): string | undefined {
-    return dataset?.administrativeInformation?.publicationAndOwnership?.['common:dataSetVersion'];
+  private dataSetVersion(
+    dataset: Flow['flowDataSet'] | undefined
+  ): string | undefined {
+    return dataset?.administrativeInformation?.publicationAndOwnership?.[
+      'common:dataSetVersion'
+    ];
   }
 
-  private geography(flowInfo: Flow['flowDataSet']['flowInformation'] | undefined, lang: string): string | undefined {
+  private geography(
+    flowInfo: Flow['flowDataSet']['flowInformation'] | undefined
+  ): string | undefined {
     const location = flowInfo?.geography?.locationOfSupply;
     if (!location) return undefined;
     return `**Location of Supply:** ${location}`;
   }
 
-  private technology(flowInfo: Flow['flowDataSet']['flowInformation'] | undefined, lang: string): string | undefined {
+  private technology(
+    flowInfo: Flow['flowDataSet']['flowInformation'] | undefined,
+    lang: string
+  ): string | undefined {
     return joinTexts(flowInfo?.technology?.technologicalApplicability, lang);
   }
 
-  private flowProperties(dataset: Flow['flowDataSet'] | undefined, lang: string): string[] {
+  private flowProperties(
+    dataset: Flow['flowDataSet'] | undefined,
+    lang: string
+  ): string[] {
     const items = ensureArray<any>(dataset?.flowProperties?.flowProperty);
-    return items.map(item => {
+    return items.map((item) => {
       const ref = (item as any).referenceToFlowPropertyDataSet;
       const name = pickShortDescription(ref, lang) ?? 'Flow property';
       const mean = formatNumber((item as any).meanValue);
@@ -340,9 +374,13 @@ export class TidasFlow extends TidasEntity<Flow> {
     });
   }
 
-  private methodology(dataset: Flow['flowDataSet'] | undefined): string | undefined {
+  private methodology(
+    dataset: Flow['flowDataSet'] | undefined
+  ): string | undefined {
     const lci = dataset?.modellingAndValidation?.LCIMethod;
     if (!lci) return undefined;
-    return lci.typeOfDataSet ? `**Data Set Type:** ${lci.typeOfDataSet}` : undefined;
+    return lci.typeOfDataSet
+      ? `**Data Set Type:** ${lci.typeOfDataSet}`
+      : undefined;
   }
 }

--- a/sdks/typescript/src/core/entities/TidasUnitGroup.ts
+++ b/sdks/typescript/src/core/entities/TidasUnitGroup.ts
@@ -2,7 +2,6 @@ import { TidasEntity } from '../base/TidasEntity';
 import { UnitGroupSchema } from '../../schemas';
 import { UnitGroup } from '../../types';
 import { ValidationConfig } from '../config/ValidationConfig';
-import { MultiLangArray } from '../../types/multi-lang-types';
 import { randomUUID } from '../../utils/uuid';
 
 /**

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -33,6 +33,7 @@ export * from './types';
 
 // === Zod Schemas and Validation ===
 export * from './schemas';
+export * from './parity';
 
 export {
   // Zod validation functions

--- a/sdks/typescript/src/parity/constants.ts
+++ b/sdks/typescript/src/parity/constants.ts
@@ -1,0 +1,14 @@
+export const SUPPORTED_CATEGORIES = [
+  'contacts',
+  'flowproperties',
+  'flows',
+  'lciamethods',
+  'lifecyclemodels',
+  'processes',
+  'sources',
+  'unitgroups',
+] as const;
+
+export type SupportedCategory = (typeof SUPPORTED_CATEGORIES)[number];
+
+export const CHINESE_CHARACTER_RE = /[\u3400-\u4DBF\u4E00-\u9FFF\uF900-\uFAFF]/;

--- a/sdks/typescript/src/parity/index.ts
+++ b/sdks/typescript/src/parity/index.ts
@@ -1,0 +1,4 @@
+export * from './constants';
+export * from './report';
+export * from './validate';
+export * from './validation-rules';

--- a/sdks/typescript/src/parity/report.ts
+++ b/sdks/typescript/src/parity/report.ts
@@ -1,0 +1,85 @@
+export type ValidationSeverity = 'error' | 'warning' | 'info';
+
+export interface ValidationIssue {
+  issue_code: string;
+  severity: ValidationSeverity;
+  category: string;
+  file_path: string;
+  message: string;
+  location: string;
+  context: Record<string, unknown>;
+}
+
+export interface ValidationSummary {
+  issue_count: number;
+  error_count: number;
+  warning_count: number;
+  info_count: number;
+}
+
+export interface CategoryValidationReport {
+  category: string;
+  ok: boolean;
+  summary: ValidationSummary;
+  issues: ValidationIssue[];
+}
+
+export interface PackageValidationSummary extends ValidationSummary {
+  category_count: number;
+}
+
+export interface PackageValidationReport {
+  input_dir: string;
+  ok: boolean;
+  summary: PackageValidationSummary;
+  categories: CategoryValidationReport[];
+  issues: ValidationIssue[];
+}
+
+export function summarizeIssues(issues: ValidationIssue[]): ValidationSummary {
+  const errorCount = issues.filter(
+    (issue) => issue.severity === 'error'
+  ).length;
+  const warningCount = issues.filter(
+    (issue) => issue.severity === 'warning'
+  ).length;
+  const infoCount = issues.filter((issue) => issue.severity === 'info').length;
+
+  return {
+    issue_count: issues.length,
+    error_count: errorCount,
+    warning_count: warningCount,
+    info_count: infoCount,
+  };
+}
+
+export function buildCategoryReport(
+  category: string,
+  issues: ValidationIssue[]
+): CategoryValidationReport {
+  return {
+    category,
+    ok: issues.length === 0,
+    summary: summarizeIssues(issues),
+    issues,
+  };
+}
+
+export function buildPackageReport(
+  inputDir: string,
+  categoryReports: CategoryValidationReport[]
+): PackageValidationReport {
+  const issues = categoryReports.flatMap((report) => report.issues);
+  const summary = summarizeIssues(issues);
+
+  return {
+    input_dir: inputDir,
+    ok: issues.length === 0,
+    summary: {
+      category_count: categoryReports.length,
+      ...summary,
+    },
+    categories: categoryReports,
+    issues,
+  };
+}

--- a/sdks/typescript/src/parity/validate.test.ts
+++ b/sdks/typescript/src/parity/validate.test.ts
@@ -1,0 +1,217 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { validatePackageDir } from './validate';
+
+function packageRoot() {
+  return path.resolve(__dirname, '../..');
+}
+
+function repoRoot() {
+  return path.resolve(packageRoot(), '../..');
+}
+
+function testDataPath(fileName: string) {
+  return path.join(repoRoot(), 'test-data', fileName);
+}
+
+function makeTempDir(prefix: string) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function makeFlowPackageFromExample() {
+  const dir = makeTempDir('tidas-sdk-validate-example-');
+  fs.mkdirSync(path.join(dir, 'flows'), { recursive: true });
+  fs.copyFileSync(
+    testDataPath('tidas-example-flow.json'),
+    path.join(dir, 'flows/example.json')
+  );
+  return dir;
+}
+
+function makeCustomInvalidFlowPackage() {
+  const dir = makeTempDir('tidas-sdk-validate-custom-');
+  fs.mkdirSync(path.join(dir, 'flows'), { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'flows/bad.json'),
+    JSON.stringify(
+      {
+        flowDataSet: {
+          '@xmlns': 'http://lca.jrc.it/ILCD/Flow',
+          '@xmlns:common': 'http://lca.jrc.it/ILCD/Common',
+          '@xmlns:ecn':
+            'http://eplca.jrc.ec.europa.eu/ILCD/Extensions/2018/ECNumber',
+          '@xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance',
+          '@version': '1.1',
+          '@locations': '../ILCDLocations.xml',
+          '@xsi:schemaLocation':
+            'http://lca.jrc.it/ILCD/Flow ../../schemas/ILCD_FlowDataSet.xsd',
+          flowInformation: {
+            dataSetInformation: {
+              'common:UUID': '12345678-1234-1234-1234-123456789abc',
+              name: {
+                baseName: [
+                  {
+                    '@xml:lang': 'en',
+                    '#text': 'English 中文',
+                  },
+                ],
+                treatmentStandardsRoutes: [
+                  {
+                    '@xml:lang': 'en',
+                    '#text': 'route',
+                  },
+                ],
+                mixAndLocationTypes: [
+                  {
+                    '@xml:lang': 'en',
+                    '#text': 'mix',
+                  },
+                ],
+              },
+              classificationInformation: {
+                'common:classification': {
+                  'common:class': [
+                    {
+                      '@level': '0',
+                      '@classId': '1',
+                      '#text': 'Top',
+                    },
+                    {
+                      '@level': '1',
+                      '@classId': '99',
+                      '#text': 'Bad child',
+                    },
+                  ],
+                },
+              },
+            },
+            quantitativeReference: {
+              referenceToReferenceFlowProperty: '1',
+            },
+          },
+          modellingAndValidation: {
+            LCIMethod: {
+              typeOfDataSet: 'Product flow',
+            },
+            complianceDeclarations: {
+              compliance: {
+                'common:referenceToComplianceSystem': {
+                  '@type': 'source data set',
+                  '@refObjectId': '12345678-1234-1234-1234-123456789abc',
+                  '@version': '00.00.000',
+                  '@uri': '',
+                  'common:shortDescription': [
+                    {
+                      '@xml:lang': 'en',
+                      '#text': 'desc',
+                    },
+                  ],
+                },
+                'common:approvalOfOverallCompliance': 'Fully compliant',
+              },
+            },
+          },
+          administrativeInformation: {
+            dataEntryBy: {
+              'common:timeStamp': '2024-01-01T00:00:00Z',
+              'common:referenceToDataSetFormat': {
+                '@type': 'source data set',
+                '@refObjectId': '12345678-1234-1234-1234-123456789abc',
+                '@version': '00.00.000',
+                '@uri': '',
+                'common:shortDescription': [
+                  {
+                    '@xml:lang': 'en',
+                    '#text': 'desc',
+                  },
+                ],
+              },
+            },
+            publicationAndOwnership: {
+              'common:dataSetVersion': '1.0.0',
+              'common:referenceToOwnershipOfDataSet': {
+                '@type': 'source data set',
+                '@refObjectId': '12345678-1234-1234-1234-123456789abc',
+                '@version': '00.00.000',
+                '@uri': '',
+                'common:shortDescription': [
+                  {
+                    '@xml:lang': 'en',
+                    '#text': 'desc',
+                  },
+                ],
+              },
+            },
+          },
+          flowProperties: {
+            flowProperty: [],
+          },
+        },
+      },
+      null,
+      2
+    ),
+    'utf8'
+  );
+  return dir;
+}
+
+describe('package validation parity', () => {
+  it('matches the tidas-tools issue count for the example flow package', () => {
+    const inputDir = makeFlowPackageFromExample();
+    const report = validatePackageDir(inputDir);
+    const locations = report.issues.map((issue) => issue.location);
+
+    expect(report.ok).toBe(false);
+    expect(report.summary.category_count).toBe(1);
+    expect(report.summary.issue_count).toBe(11);
+    expect(report.summary.error_count).toBe(11);
+    expect(report.categories).toHaveLength(1);
+    expect(report.categories[0]?.category).toBe('flows');
+    expect(report.categories[0]?.summary.issue_count).toBe(11);
+    expect(new Set(report.issues.map((issue) => issue.issue_code))).toEqual(
+      new Set(['schema_error'])
+    );
+    expect(locations).toEqual(
+      expect.arrayContaining([
+        'flowDataSet',
+        'flowDataSet/flowInformation/dataSetInformation/name',
+        'flowDataSet/flowInformation/dataSetInformation/common:other',
+        'flowDataSet/administrativeInformation/publicationAndOwnership',
+        'flowDataSet/flowInformation/dataSetInformation/classificationInformation/common:elementaryFlowCategorization/common:category/0',
+      ])
+    );
+    expect(locations).not.toContain(
+      'flowDataSet/administrativeInformation/dataEntryBy/common:timeStamp'
+    );
+  });
+
+  it('emits localized text and classification hierarchy issues on top of schema issues', () => {
+    const inputDir = makeCustomInvalidFlowPackage();
+    const report = validatePackageDir(inputDir);
+    const issueCodes = report.issues.map((issue) => issue.issue_code);
+
+    expect(report.summary.issue_count).toBe(3);
+    expect(issueCodes).toEqual(
+      expect.arrayContaining([
+        'schema_error',
+        'localized_text_language_error',
+        'classification_hierarchy_error',
+      ])
+    );
+    expect(report.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          issue_code: 'localized_text_language_error',
+          location:
+            'flowDataSet/flowInformation/dataSetInformation/name/baseName/0',
+        }),
+        expect.objectContaining({
+          issue_code: 'classification_hierarchy_error',
+          location: '<root>',
+        }),
+      ])
+    );
+  });
+});

--- a/sdks/typescript/src/parity/validate.ts
+++ b/sdks/typescript/src/parity/validate.ts
@@ -1,0 +1,341 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import type { ZodIssue } from 'zod';
+import {
+  ContactSchema,
+  FlowPropertySchema,
+  FlowSchema,
+  LCIAMethodSchema,
+  LifeCycleModelSchema,
+  ProcessSchema,
+  SourceSchema,
+  UnitGroupSchema,
+} from '../schemas';
+import { SUPPORTED_CATEGORIES, type SupportedCategory } from './constants';
+import {
+  collectClassificationIssues,
+  collectFlowSchemaGapIssues,
+  collectLocalizedTextIssues,
+} from './validation-rules';
+import {
+  buildCategoryReport,
+  buildPackageReport,
+  type CategoryValidationReport,
+  type PackageValidationReport,
+  type ValidationIssue,
+} from './report';
+
+type SchemaValidator = {
+  safeParse(
+    data: unknown
+  ):
+    | { success: true; data: unknown }
+    | { success: false; error: { issues: ZodIssue[] } };
+};
+
+type NormalizedPath = Array<string | number>;
+
+type NormalizedIssue = {
+  code: ZodIssue['code'] | 'missing_union_value';
+  path: NormalizedPath;
+  message: string;
+  format?: string;
+  expected?: string;
+  values?: unknown[];
+};
+
+const CATEGORY_SCHEMAS: Record<SupportedCategory, SchemaValidator> = {
+  contacts: ContactSchema,
+  flowproperties: FlowPropertySchema,
+  flows: FlowSchema,
+  lciamethods: LCIAMethodSchema,
+  lifecyclemodels: LifeCycleModelSchema,
+  processes: ProcessSchema,
+  sources: SourceSchema,
+  unitgroups: UnitGroupSchema,
+};
+
+function toLocation(pathParts: Array<string | number>) {
+  return pathParts.length === 0 ? '<root>' : pathParts.join('/');
+}
+
+function normalizePath(
+  pathParts: ReadonlyArray<PropertyKey> | undefined
+): NormalizedPath {
+  return (pathParts ?? []).filter(
+    (part): part is string | number =>
+      typeof part === 'string' || typeof part === 'number'
+  );
+}
+
+function getValueAtPath(root: unknown, pathParts: Array<string | number>) {
+  let current = root;
+  for (const part of pathParts) {
+    if (current === null || current === undefined) {
+      return undefined;
+    }
+    if (typeof part === 'number') {
+      if (!Array.isArray(current)) {
+        return undefined;
+      }
+      current = current[part];
+      continue;
+    }
+    if (typeof current !== 'object') {
+      return undefined;
+    }
+    current = (current as Record<string, unknown>)[part];
+  }
+  return current;
+}
+
+function isJsonSchemaDateTimeLike(value: unknown) {
+  return (
+    typeof value === 'string' &&
+    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/.test(
+      value
+    )
+  );
+}
+
+function normalizeUnionIssue(
+  issue: ZodIssue & { errors?: ZodIssue[][] },
+  prefix: Array<string | number>
+): NormalizedIssue[] {
+  const currentPath = [...prefix, ...normalizePath(issue.path)];
+  const childIssues = (issue.errors ?? []).flatMap((branch) =>
+    branch.flatMap((child) => normalizeZodIssue(child, currentPath))
+  );
+  const deeperChildren = childIssues.filter(
+    (child) => child.path.length > currentPath.length
+  );
+
+  if (deeperChildren.length > 0) {
+    return deeperChildren;
+  }
+
+  const onlyGenericUnionMisses =
+    childIssues.length > 0 &&
+    childIssues.every(
+      (child) =>
+        child.code === 'invalid_type' &&
+        (child as { expected?: string }).expected !== undefined &&
+        ['array', 'object'].includes(
+          String((child as { expected?: string }).expected)
+        )
+    );
+
+  if (onlyGenericUnionMisses) {
+    return [
+      {
+        code: 'missing_union_value',
+        path: currentPath,
+        message: 'Missing union value',
+      },
+    ];
+  }
+
+  return childIssues;
+}
+
+function normalizeZodIssue(
+  issue: ZodIssue,
+  prefix: Array<string | number> = []
+): NormalizedIssue[] {
+  const unionIssue = issue as ZodIssue & { errors?: ZodIssue[][] };
+  if (unionIssue.code === 'invalid_union' && Array.isArray(unionIssue.errors)) {
+    return normalizeUnionIssue(unionIssue, prefix);
+  }
+
+  return [
+    {
+      code: issue.code,
+      path: [...prefix, ...normalizePath(issue.path)],
+      message: issue.message,
+      format: 'format' in issue ? issue.format : undefined,
+      expected: 'expected' in issue ? String(issue.expected) : undefined,
+      values: 'values' in issue ? issue.values : undefined,
+    },
+  ];
+}
+
+function shouldIgnoreIssue(issue: NormalizedIssue, jsonItem: unknown) {
+  if (issue.code === 'invalid_format' && issue.format === 'datetime') {
+    return isJsonSchemaDateTimeLike(getValueAtPath(jsonItem, issue.path));
+  }
+  return false;
+}
+
+function createSchemaIssue(
+  category: string,
+  filePath: string,
+  issue: NormalizedIssue
+): ValidationIssue {
+  const rawLocation = issue.path;
+  const valueAtPath =
+    rawLocation.length > 0 ? rawLocation[rawLocation.length - 1] : '';
+
+  if (
+    issue.code === 'missing_union_value' &&
+    typeof valueAtPath === 'string' &&
+    rawLocation.length > 0
+  ) {
+    const parentLocation = toLocation(rawLocation.slice(0, -1));
+    return {
+      issue_code: 'schema_error',
+      severity: 'error',
+      category,
+      file_path: filePath,
+      location: parentLocation,
+      message: `Schema Error at ${parentLocation}: '${valueAtPath}' is a required property`,
+      context: {
+        validator: 'required',
+      },
+    };
+  }
+
+  if (
+    issue.code === 'invalid_value' &&
+    typeof valueAtPath === 'string' &&
+    rawLocation.length > 0
+  ) {
+    const parentLocation = toLocation(rawLocation.slice(0, -1));
+    return {
+      issue_code: 'schema_error',
+      severity: 'error',
+      category,
+      file_path: filePath,
+      location: parentLocation,
+      message: `Schema Error at ${parentLocation}: '${valueAtPath}' is a required property`,
+      context: {
+        validator: 'required',
+      },
+    };
+  }
+
+  const location = toLocation(rawLocation);
+  return {
+    issue_code: 'schema_error',
+    severity: 'error',
+    category,
+    file_path: filePath,
+    location,
+    message: `Schema Error at ${location}: ${issue.message}`,
+    context: {
+      validator:
+        issue.code === 'invalid_type'
+          ? 'type'
+          : issue.code === 'invalid_format'
+            ? 'format'
+            : issue.code,
+    },
+  };
+}
+
+function dedupeIssues(issues: ValidationIssue[]) {
+  const seen = new Set<string>();
+  const deduped: ValidationIssue[] = [];
+
+  for (const issue of issues) {
+    const key = `${issue.issue_code}|${issue.file_path}|${issue.location}|${issue.message}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    deduped.push(issue);
+  }
+
+  return deduped;
+}
+
+function collectSchemaIssues(
+  schema: SchemaValidator,
+  jsonItem: unknown,
+  category: SupportedCategory,
+  filePath: string
+) {
+  const result = schema.safeParse(jsonItem);
+  if (result.success) {
+    return [];
+  }
+
+  return result.error.issues
+    .flatMap((issue) => normalizeZodIssue(issue))
+    .filter((issue) => !shouldIgnoreIssue(issue, jsonItem))
+    .map((issue) => createSchemaIssue(category, filePath, issue));
+}
+
+export function categoryValidate(
+  jsonFilePath: string,
+  category: SupportedCategory,
+  emitLogs = true
+): CategoryValidationReport {
+  const issues: ValidationIssue[] = [];
+  const schema = CATEGORY_SCHEMAS[category];
+
+  for (const fileName of readdirSync(jsonFilePath).sort()) {
+    if (!fileName.endsWith('.json')) {
+      continue;
+    }
+
+    const fullPath = path.join(jsonFilePath, fileName);
+    let jsonItem: unknown;
+
+    try {
+      jsonItem = JSON.parse(readFileSync(fullPath, 'utf8'));
+    } catch (error) {
+      issues.push({
+        issue_code: 'invalid_json',
+        severity: 'error',
+        category,
+        file_path: fullPath,
+        location: '<root>',
+        message: `Invalid JSON: ${error instanceof Error ? error.name : 'Error'}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+        context: {},
+      });
+      continue;
+    }
+
+    const itemIssues = dedupeIssues([
+      ...collectSchemaIssues(schema, jsonItem, category, fullPath),
+      ...collectLocalizedTextIssues(jsonItem, category, fullPath),
+      ...collectFlowSchemaGapIssues(jsonItem, category, fullPath),
+      ...collectClassificationIssues(jsonItem, category, fullPath),
+    ]);
+
+    issues.push(...itemIssues);
+
+    if (!emitLogs) {
+      continue;
+    }
+
+    if (itemIssues.length === 0) {
+      console.info(`INFO: ${fullPath} PASSED.`);
+      continue;
+    }
+
+    itemIssues.forEach((issue) => {
+      console.error(`ERROR: ${fullPath} ${issue.message}`);
+    });
+  }
+
+  return buildCategoryReport(category, issues);
+}
+
+export function validatePackageDir(
+  inputDir: string,
+  emitLogs = false
+): PackageValidationReport {
+  const categoryReports = SUPPORTED_CATEGORIES.flatMap((category) => {
+    const categoryDir = path.join(inputDir, category);
+    if (!existsSync(categoryDir)) {
+      return [];
+    }
+
+    return [categoryValidate(categoryDir, category, emitLogs)];
+  });
+
+  return buildPackageReport(inputDir, categoryReports);
+}

--- a/sdks/typescript/src/parity/validation-rules.ts
+++ b/sdks/typescript/src/parity/validation-rules.ts
@@ -1,0 +1,541 @@
+import { CHINESE_CHARACTER_RE } from './constants';
+import type { ValidationIssue } from './report';
+
+interface ClassificationValidationResult {
+  valid: boolean;
+  errors?: string[];
+}
+
+function makeIssue(
+  category: string,
+  filePath: string,
+  location: string,
+  message: string,
+  issueCode = 'schema_error'
+): ValidationIssue {
+  return {
+    issue_code: issueCode,
+    severity: 'error',
+    category,
+    file_path: filePath,
+    location,
+    message,
+    context: {},
+  };
+}
+
+function asRecord(value: unknown) {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function ensureArray<T>(value: T | T[] | undefined | null) {
+  if (Array.isArray(value)) {
+    return value;
+  }
+  if (value === undefined || value === null) {
+    return [];
+  }
+  return [value];
+}
+
+export function validateElementaryFlowsClassificationHierarchy(
+  classItems: Array<Record<string, unknown>>
+): ClassificationValidationResult {
+  const errors: string[] = [];
+
+  classItems.forEach((item, index) => {
+    const level = Number(item['@level']);
+    if (level !== index) {
+      errors.push(
+        `Elementary flow classification level sorting error: at index ${index}, expected level ${index}, got ${level}`
+      );
+    }
+  });
+
+  for (let index = 1; index < classItems.length; index += 1) {
+    const parentId = String(classItems[index - 1]?.['@catId'] ?? '');
+    const childId = String(classItems[index]?.['@catId'] ?? '');
+    if (!childId.startsWith(parentId)) {
+      errors.push(
+        `Elementary flow classification code error: child code '${childId}' does not start with parent code '${parentId}'`
+      );
+    }
+  }
+
+  return errors.length > 0 ? { valid: false, errors } : { valid: true };
+}
+
+export function validateProductFlowsClassificationHierarchy(
+  classItems: Array<Record<string, unknown>>
+): ClassificationValidationResult {
+  const errors: string[] = [];
+
+  classItems.forEach((item, index) => {
+    const level = Number(item['@level']);
+    if (level !== index) {
+      errors.push(
+        `Product flow classification level sorting error: at index ${index}, expected level ${index}, got ${level}`
+      );
+    }
+  });
+
+  for (let index = 1; index < classItems.length; index += 1) {
+    const parentId = String(classItems[index - 1]?.['@classId'] ?? '');
+    const childId = String(classItems[index]?.['@classId'] ?? '');
+    if (!childId.startsWith(parentId)) {
+      errors.push(
+        `Product flow classification code error: child code '${childId}' does not start with parent code '${parentId}'`
+      );
+    }
+  }
+
+  return errors.length > 0 ? { valid: false, errors } : { valid: true };
+}
+
+export function validateProcessesClassificationHierarchy(
+  classItems: Array<Record<string, unknown>>
+): ClassificationValidationResult {
+  const errors: string[] = [];
+  const level0ToLevel1Mapping: Record<string, string[]> = {
+    A: ['01', '02', '03'],
+    B: ['05', '06', '07', '08', '09'],
+    C: Array.from({ length: 24 }, (_, index) =>
+      String(index + 10).padStart(2, '0')
+    ),
+    D: ['35'],
+    E: ['36', '37', '38', '39'],
+    F: ['41', '42', '43'],
+    G: ['46', '47'],
+    H: ['49', '50', '51', '52', '53'],
+    I: ['55', '56'],
+    J: ['58', '59', '60'],
+    K: ['61', '62', '63'],
+    L: ['64', '65', '66'],
+    M: ['68'],
+    N: ['69', '70', '71', '72', '73', '74', '75'],
+    O: ['77', '78', '79', '80', '81', '82'],
+    P: ['84'],
+    Q: ['85'],
+    R: ['86', '87', '88'],
+    S: ['90', '91', '92', '93'],
+    T: ['94', '95', '96'],
+    U: ['97', '98'],
+    V: ['99'],
+  };
+
+  classItems.forEach((item, index) => {
+    const level = Number(item['@level']);
+    if (level !== index) {
+      errors.push(
+        `Processes classification level sorting error: at index ${index}, expected level ${index}, got ${level}`
+      );
+    }
+  });
+
+  for (let index = 1; index < classItems.length; index += 1) {
+    const parent = classItems[index - 1] ?? {};
+    const child = classItems[index] ?? {};
+    const parentLevel = Number(parent['@level']);
+    const childLevel = Number(child['@level']);
+    const parentId = String(parent['@classId'] ?? '');
+    const childId = String(child['@classId'] ?? '');
+
+    if (parentLevel === 0 && childLevel === 1) {
+      const validCodes = level0ToLevel1Mapping[parentId] ?? [];
+      if (!validCodes.includes(childId)) {
+        errors.push(
+          `Processes classification code error: level 1 code '${childId}' does not correspond to level 0 code '${parentId}'`
+        );
+      }
+      continue;
+    }
+
+    if (!childId.startsWith(parentId)) {
+      errors.push(
+        `Processes classification code error: child code '${childId}' does not start with parent code '${parentId}'`
+      );
+    }
+  }
+
+  return errors.length > 0 ? { valid: false, errors } : { valid: true };
+}
+
+export function validateSourcesClassificationHierarchy(
+  classItems:
+    | Array<Record<string, unknown>>
+    | Record<string, unknown>
+    | undefined
+): ClassificationValidationResult {
+  const normalizedItems = ensureArray(classItems);
+  const errors: string[] = [];
+
+  normalizedItems.forEach((item, index) => {
+    const level = Number(item['@level']);
+    if (!Number.isFinite(level)) {
+      errors.push(
+        `Sources classification level parsing error: missing or invalid '@level' at index ${index}`
+      );
+      return;
+    }
+    if (level !== index) {
+      errors.push(
+        `Sources classification level sorting error: at index ${index}, expected level ${index}, got ${level}`
+      );
+    }
+  });
+
+  for (let index = 1; index < normalizedItems.length; index += 1) {
+    const parentId = normalizedItems[index - 1]?.['@classId'];
+    const childId = normalizedItems[index]?.['@classId'];
+    if (typeof parentId !== 'string' || typeof childId !== 'string') {
+      errors.push(
+        `Sources classification code error: missing '@classId' for parent index ${index - 1} or child index ${index}`
+      );
+      continue;
+    }
+    if (!childId.startsWith(parentId)) {
+      errors.push(
+        `Sources classification code error: child code '${childId}' does not start with parent code '${parentId}'`
+      );
+    }
+  }
+
+  return errors.length > 0 ? { valid: false, errors } : { valid: true };
+}
+
+export function validateLocalizedTextLanguageConstraints(
+  node: unknown,
+  currentPath = ''
+): string[] {
+  const errors: string[] = [];
+  const currentNode = asRecord(node);
+
+  if (currentNode) {
+    const language = currentNode['@xml:lang'];
+    const text = currentNode['#text'];
+    const location = currentPath || '<root>';
+
+    if (typeof language === 'string' && typeof text === 'string') {
+      const normalizedLanguage = language.toLowerCase();
+      const hasChinese = CHINESE_CHARACTER_RE.test(text);
+
+      if (
+        (normalizedLanguage === 'zh' || normalizedLanguage.startsWith('zh-')) &&
+        !hasChinese
+      ) {
+        errors.push(
+          `Localized text error at ${location}: @xml:lang '${language}' must include at least one Chinese character`
+        );
+      }
+
+      if (
+        (normalizedLanguage === 'en' || normalizedLanguage.startsWith('en-')) &&
+        hasChinese
+      ) {
+        errors.push(
+          `Localized text error at ${location}: @xml:lang '${language}' must not contain Chinese characters`
+        );
+      }
+    }
+
+    for (const [key, value] of Object.entries(currentNode)) {
+      const childPath = currentPath ? `${currentPath}/${key}` : key;
+      errors.push(
+        ...validateLocalizedTextLanguageConstraints(value, childPath)
+      );
+    }
+    return errors;
+  }
+
+  if (Array.isArray(node)) {
+    node.forEach((value, index) => {
+      const childPath = currentPath ? `${currentPath}/${index}` : String(index);
+      errors.push(
+        ...validateLocalizedTextLanguageConstraints(value, childPath)
+      );
+    });
+  }
+
+  return errors;
+}
+
+function collectFlowClassificationStructureIssues(
+  items: unknown,
+  category: string,
+  filePath: string,
+  locationBase: string,
+  requiredIdKey: '@classId' | '@catId'
+) {
+  if (!Array.isArray(items)) {
+    return [];
+  }
+
+  const issues: ValidationIssue[] = [];
+
+  items.forEach((item, index) => {
+    const record = asRecord(item);
+    if (!record) {
+      return;
+    }
+
+    for (const fieldName of ['@level', requiredIdKey, '#text'] as const) {
+      if (record[fieldName] !== undefined) {
+        continue;
+      }
+
+      issues.push(
+        makeIssue(
+          category,
+          filePath,
+          `${locationBase}/${index}`,
+          `Schema Error at ${locationBase}/${index}: '${fieldName}' is a required property`
+        )
+      );
+    }
+  });
+
+  return issues;
+}
+
+export function collectLocalizedTextIssues(
+  jsonItem: unknown,
+  category: string,
+  filePath: string
+) {
+  return validateLocalizedTextLanguageConstraints(jsonItem).map((message) => {
+    const location =
+      message.startsWith('Localized text error at ') && message.includes(':')
+        ? message.split('Localized text error at ', 2)[1]!.split(':', 1)[0]!
+        : '<root>';
+
+    return makeIssue(
+      category,
+      filePath,
+      location,
+      message,
+      'localized_text_language_error'
+    );
+  });
+}
+
+export function collectFlowSchemaGapIssues(
+  jsonItem: unknown,
+  category: string,
+  filePath: string
+) {
+  if (category !== 'flows') {
+    return [];
+  }
+
+  const flowDataSet = asRecord(asRecord(jsonItem)?.flowDataSet);
+  const modellingAndValidation = asRecord(flowDataSet?.modellingAndValidation);
+  const lciMethod = asRecord(modellingAndValidation?.LCIMethod);
+  const dataSetType = lciMethod?.typeOfDataSet;
+  const dataSetInformation = asRecord(
+    asRecord(flowDataSet?.flowInformation)?.dataSetInformation
+  );
+  const classificationInformation = asRecord(
+    dataSetInformation?.classificationInformation
+  );
+
+  if (dataSetType === 'Product flow') {
+    const classes = asRecord(
+      classificationInformation?.['common:classification']
+    )?.['common:class'];
+    return collectFlowClassificationStructureIssues(
+      classes,
+      category,
+      filePath,
+      'flowDataSet/flowInformation/dataSetInformation/classificationInformation/common:classification/common:class',
+      '@classId'
+    );
+  }
+
+  if (dataSetType === 'Elementary flow') {
+    const categories = asRecord(
+      classificationInformation?.['common:elementaryFlowCategorization']
+    )?.['common:category'];
+
+    return collectFlowClassificationStructureIssues(
+      categories,
+      category,
+      filePath,
+      'flowDataSet/flowInformation/dataSetInformation/classificationInformation/common:elementaryFlowCategorization/common:category',
+      '@catId'
+    );
+  }
+
+  return [];
+}
+
+export function collectClassificationIssues(
+  jsonItem: unknown,
+  category: string,
+  filePath: string
+) {
+  const issues: ValidationIssue[] = [];
+  const root = asRecord(jsonItem);
+
+  try {
+    if (category === 'flows') {
+      const flowDataSet = asRecord(asRecord(root?.flowDataSet));
+      const dataSetType = asRecord(flowDataSet?.modellingAndValidation)
+        ?.LCIMethod
+        ? asRecord(asRecord(flowDataSet?.modellingAndValidation)?.LCIMethod)?.[
+            'typeOfDataSet'
+          ]
+        : undefined;
+
+      if (dataSetType === 'Product flow') {
+        const items = asRecord(
+          asRecord(
+            asRecord(asRecord(flowDataSet?.flowInformation)?.dataSetInformation)
+              ?.classificationInformation
+          )?.['common:classification']
+        )?.['common:class'];
+
+        if (Array.isArray(items)) {
+          const result = validateProductFlowsClassificationHierarchy(
+            items.filter((item): item is Record<string, unknown> =>
+              Boolean(asRecord(item))
+            )
+          );
+          if (!result.valid) {
+            issues.push(
+              ...(result.errors ?? []).map((message) =>
+                makeIssue(
+                  category,
+                  filePath,
+                  '<root>',
+                  message,
+                  'classification_hierarchy_error'
+                )
+              )
+            );
+          }
+        }
+      } else if (dataSetType === 'Elementary flow') {
+        const items = asRecord(
+          asRecord(
+            asRecord(asRecord(flowDataSet?.flowInformation)?.dataSetInformation)
+              ?.classificationInformation
+          )?.['common:elementaryFlowCategorization']
+        )?.['common:category'];
+
+        if (Array.isArray(items)) {
+          const result = validateElementaryFlowsClassificationHierarchy(
+            items.filter((item): item is Record<string, unknown> =>
+              Boolean(asRecord(item))
+            )
+          );
+          if (!result.valid) {
+            issues.push(
+              ...(result.errors ?? []).map((message) =>
+                makeIssue(
+                  category,
+                  filePath,
+                  '<root>',
+                  message,
+                  'classification_hierarchy_error'
+                )
+              )
+            );
+          }
+        }
+      }
+    } else if (category === 'processes') {
+      const items = asRecord(
+        asRecord(
+          asRecord(asRecord(root?.processDataSet)?.processInformation)
+            ?.dataSetInformation
+        )?.classificationInformation
+      )?.['common:classification'];
+
+      const classes = asRecord(items)?.['common:class'];
+      if (Array.isArray(classes)) {
+        const result = validateProcessesClassificationHierarchy(
+          classes.filter((item): item is Record<string, unknown> =>
+            Boolean(asRecord(item))
+          )
+        );
+        if (!result.valid) {
+          issues.push(
+            ...(result.errors ?? []).map((message) =>
+              makeIssue(
+                category,
+                filePath,
+                '<root>',
+                message,
+                'classification_hierarchy_error'
+              )
+            )
+          );
+        }
+      }
+    } else if (category === 'lifecyclemodels') {
+      const items = asRecord(
+        asRecord(
+          asRecord(root?.lifecycleModelDataSet)?.lifecycleModelInformation
+        )?.dataSetInformation
+      )?.classificationInformation;
+
+      const classes = asRecord(asRecord(items)?.['common:classification'])?.[
+        'common:class'
+      ];
+      if (Array.isArray(classes)) {
+        const result = validateProcessesClassificationHierarchy(
+          classes.filter((item): item is Record<string, unknown> =>
+            Boolean(asRecord(item))
+          )
+        );
+        if (!result.valid) {
+          issues.push(
+            ...(result.errors ?? []).map((message) =>
+              makeIssue(
+                category,
+                filePath,
+                '<root>',
+                message,
+                'classification_hierarchy_error'
+              )
+            )
+          );
+        }
+      }
+    } else if (category === 'sources') {
+      const classes = asRecord(
+        asRecord(
+          asRecord(asRecord(root?.sourceDataSet)?.sourceInformation)
+            ?.dataSetInformation
+        )?.classificationInformation
+      );
+      const result = validateSourcesClassificationHierarchy(
+        asRecord(asRecord(classes)?.['common:classification'])?.[
+          'common:class'
+        ] as
+          | Array<Record<string, unknown>>
+          | Record<string, unknown>
+          | undefined
+      );
+      if (!result.valid) {
+        issues.push(
+          ...(result.errors ?? []).map((message) =>
+            makeIssue(
+              category,
+              filePath,
+              '<root>',
+              message,
+              'classification_hierarchy_error'
+            )
+          )
+        );
+      }
+    }
+  } catch {
+    return issues;
+  }
+
+  return issues;
+}

--- a/sdks/typescript/src/types/tidas_flows_product_category.ts
+++ b/sdks/typescript/src/types/tidas_flows_product_category.ts
@@ -2704,12 +2704,12 @@ export type FlowsProductCategory =
   | {
       '@level'?: '3';
       '@classId'?: '2318';
-      '#text'?: "Mixes and doughs for the preparation of bakers\' wares";
+      '#text'?: "Mixes and doughs for the preparation of bakers' wares";
     }
   | {
       '@level'?: '4';
       '@classId'?: '23180';
-      '#text'?: "Mixes and doughs for the preparation of bakers\' wares";
+      '#text'?: "Mixes and doughs for the preparation of bakers' wares";
     }
   | {
       '@level'?: '2';
@@ -2802,12 +2802,12 @@ export type FlowsProductCategory =
   | {
       '@level'?: '3';
       '@classId'?: '2349';
-      '#text'?: "Bread and other bakers\' wares";
+      '#text'?: "Bread and other bakers' wares";
     }
   | {
       '@level'?: '4';
       '@classId'?: '23490';
-      '#text'?: "Bread and other bakers\' wares";
+      '#text'?: "Bread and other bakers' wares";
     }
   | { '@level'?: '2'; '@classId'?: '235'; '#text'?: 'Sugar and molasses' }
   | { '@level'?: '3'; '@classId'?: '2351'; '#text'?: 'Raw cane or beet sugar' }
@@ -4003,22 +4003,22 @@ export type FlowsProductCategory =
   | {
       '@level'?: '4';
       '@classId'?: '28221';
-      '#text'?: "Men\'s or boys\' suits, coats, jackets, trousers, shorts and the like, knitted or crocheted";
+      '#text'?: "Men's or boys' suits, coats, jackets, trousers, shorts and the like, knitted or crocheted";
     }
   | {
       '@level'?: '4';
       '@classId'?: '28222';
-      '#text'?: "Men\'s or boys\' shirts, underpants, pyjamas, dressing gowns and similar articles, knitted or crocheted";
+      '#text'?: "Men's or boys' shirts, underpants, pyjamas, dressing gowns and similar articles, knitted or crocheted";
     }
   | {
       '@level'?: '4';
       '@classId'?: '28223';
-      '#text'?: "Women\'s or girls\' suits, coats, jackets, dresses, skirts, trousers, shorts and the like, knitted or crocheted";
+      '#text'?: "Women's or girls' suits, coats, jackets, dresses, skirts, trousers, shorts and the like, knitted or crocheted";
     }
   | {
       '@level'?: '4';
       '@classId'?: '28224';
-      '#text'?: "Women\'s or girls\' blouses, shirts, petticoats, panties, nightdresses, dressing gowns and similar articles, knitted or crocheted";
+      '#text'?: "Women's or girls' blouses, shirts, petticoats, panties, nightdresses, dressing gowns and similar articles, knitted or crocheted";
     }
   | {
       '@level'?: '4';
@@ -4033,7 +4033,7 @@ export type FlowsProductCategory =
   | {
       '@level'?: '4';
       '@classId'?: '28227';
-      '#text'?: "Babies\' garments and clothing accessories, knitted or crocheted";
+      '#text'?: "Babies' garments and clothing accessories, knitted or crocheted";
     }
   | {
       '@level'?: '4';
@@ -4053,27 +4053,27 @@ export type FlowsProductCategory =
   | {
       '@level'?: '4';
       '@classId'?: '28231';
-      '#text'?: "Men\'s or boys\' suits, coats, jackets, trousers, shorts and the like, of textile fabric, not knitted or crocheted";
+      '#text'?: "Men's or boys' suits, coats, jackets, trousers, shorts and the like, of textile fabric, not knitted or crocheted";
     }
   | {
       '@level'?: '4';
       '@classId'?: '28232';
-      '#text'?: "Men\'s or boys\' shirts, singlets, underpants, pyjamas, dressing gowns and similar articles, of textile fabric, not knitted or crocheted";
+      '#text'?: "Men's or boys' shirts, singlets, underpants, pyjamas, dressing gowns and similar articles, of textile fabric, not knitted or crocheted";
     }
   | {
       '@level'?: '4';
       '@classId'?: '28233';
-      '#text'?: "Women\'s or girls\' suits, coats, jackets, dresses, skirts, trousers, shorts and the like, of textile fabric, not knitted or crocheted";
+      '#text'?: "Women's or girls' suits, coats, jackets, dresses, skirts, trousers, shorts and the like, of textile fabric, not knitted or crocheted";
     }
   | {
       '@level'?: '4';
       '@classId'?: '28234';
-      '#text'?: "Women\'s or girls\' blouses, shirts, singlets, petticoats, panties, nightdresses, dressing gowns and similar articles, of textile fabric, not knitted or crocheted";
+      '#text'?: "Women's or girls' blouses, shirts, singlets, petticoats, panties, nightdresses, dressing gowns and similar articles, of textile fabric, not knitted or crocheted";
     }
   | {
       '@level'?: '4';
       '@classId'?: '28235';
-      '#text'?: "Babies\' garments and clothing accessories, of textile fabric, not knitted or crocheted";
+      '#text'?: "Babies' garments and clothing accessories, of textile fabric, not knitted or crocheted";
     }
   | {
       '@level'?: '4';
@@ -4597,14 +4597,14 @@ export type FlowsProductCategory =
   | {
       '@level'?: '2';
       '@classId'?: '316';
-      '#text'?: "Builders\' joinery and carpentry of wood (including cellular wood panels, assembled parquet panels, shingles and shakes)";
+      '#text'?: "Builders' joinery and carpentry of wood (including cellular wood panels, assembled parquet panels, shingles and shakes)";
     }
   | { '@level'?: '3'; '@classId'?: '3161'; '#text'?: 'Cellular board' }
   | { '@level'?: '4'; '@classId'?: '31610'; '#text'?: 'Cellular board' }
   | {
       '@level'?: '3';
       '@classId'?: '3162';
-      '#text'?: "Builder\'s joinery and carpentry of wood";
+      '#text'?: "Builder's joinery and carpentry of wood";
     }
   | {
       '@level'?: '4';
@@ -4644,17 +4644,17 @@ export type FlowsProductCategory =
   | {
       '@level'?: '4';
       '@classId'?: '31629';
-      '#text'?: "Other builder\'s joinery and carpentry of wood and bamboo";
+      '#text'?: "Other builder's joinery and carpentry of wood and bamboo";
     }
   | {
       '@level'?: '2';
       '@classId'?: '317';
-      '#text'?: "Packing cases, boxes, crates, drums and similar packings, of wood; cable-drums of wood; pallets, box pallets and other load boards, of wood; casks, barrels, vats, tubs and other coopers\' products and parts thereof, of wood (including staves)";
+      '#text'?: "Packing cases, boxes, crates, drums and similar packings, of wood; cable-drums of wood; pallets, box pallets and other load boards, of wood; casks, barrels, vats, tubs and other coopers' products and parts thereof, of wood (including staves)";
     }
   | {
       '@level'?: '3';
       '@classId'?: '3170';
-      '#text'?: "Packing cases, boxes, crates, drums and similar packings, of wood; cable-drums of wood; pallets, box pallets and other load boards, of wood; casks, barrels, vats, tubs and other coopers\' products and parts thereof, of wood (including staves)";
+      '#text'?: "Packing cases, boxes, crates, drums and similar packings, of wood; cable-drums of wood; pallets, box pallets and other load boards, of wood; casks, barrels, vats, tubs and other coopers' products and parts thereof, of wood (including staves)";
     }
   | {
       '@level'?: '4';
@@ -4669,7 +4669,7 @@ export type FlowsProductCategory =
   | {
       '@level'?: '4';
       '@classId'?: '31703';
-      '#text'?: "Casks, barrels, vats, tubs and other coopers\' products and parts thereof, of wood, including staves";
+      '#text'?: "Casks, barrels, vats, tubs and other coopers' products and parts thereof, of wood, including staves";
     }
   | {
       '@level'?: '4';
@@ -4943,7 +4943,7 @@ export type FlowsProductCategory =
   | {
       '@level'?: '4';
       '@classId'?: '32292';
-      '#text'?: "Children\'s books, in print";
+      '#text'?: "Children's books, in print";
     }
   | {
       '@level'?: '4';
@@ -5569,17 +5569,17 @@ export type FlowsProductCategory =
   | {
       '@level'?: '2';
       '@classId'?: '344';
-      '#text'?: "Activated natural mineral products; animal black; tall oil; terpenic oils produced by the treatment of coniferous woods; crude dipentene; crude para-cymene; pine oil; rosin and resin acids, and derivatives thereof; rosin spirit and rosin oils; rum gums; wood tar; wood tar oils; wood creosote; wood naphtha; vegetable pitch; brewers\' pitch";
+      '#text'?: "Activated natural mineral products; animal black; tall oil; terpenic oils produced by the treatment of coniferous woods; crude dipentene; crude para-cymene; pine oil; rosin and resin acids, and derivatives thereof; rosin spirit and rosin oils; rum gums; wood tar; wood tar oils; wood creosote; wood naphtha; vegetable pitch; brewers' pitch";
     }
   | {
       '@level'?: '3';
       '@classId'?: '3440';
-      '#text'?: "Activated natural mineral products; animal black; tall oil; terpenic oils produced by the treatment of coniferous woods; crude dipentene; crude para-cymene; pine oil; rosin and resin acids, and derivatives thereof; rosin spirit and rosin oils; rum gums; wood tar; wood tar oils; wood creosote; wood naphtha; vegetable pitch; brewers\' pitch";
+      '#text'?: "Activated natural mineral products; animal black; tall oil; terpenic oils produced by the treatment of coniferous woods; crude dipentene; crude para-cymene; pine oil; rosin and resin acids, and derivatives thereof; rosin spirit and rosin oils; rum gums; wood tar; wood tar oils; wood creosote; wood naphtha; vegetable pitch; brewers' pitch";
     }
   | {
       '@level'?: '4';
       '@classId'?: '34400';
-      '#text'?: "Activated natural mineral products; animal black; tall oil; terpenic oils produced by the treatment of coniferous woods; crude dipentene; crude para-cymene; pine oil; rosin and resin acids, and derivatives thereof; rosin spirit and rosin oils; rum gums; wood tar; wood tar oils; wood creosote; wood naphtha; vegetable pitch; brewers\' pitch";
+      '#text'?: "Activated natural mineral products; animal black; tall oil; terpenic oils produced by the treatment of coniferous woods; crude dipentene; crude para-cymene; pine oil; rosin and resin acids, and derivatives thereof; rosin spirit and rosin oils; rum gums; wood tar; wood tar oils; wood creosote; wood naphtha; vegetable pitch; brewers' pitch";
     }
   | {
       '@level'?: '2';
@@ -5715,7 +5715,7 @@ export type FlowsProductCategory =
   | {
       '@level'?: '4';
       '@classId'?: '34644';
-      '#text'?: "Fertilizers containing two nutrients: nitrogen and phosphorus; other than diammonium phosphate and monoammonium phosphate\'";
+      '#text'?: "Fertilizers containing two nutrients: nitrogen and phosphorus; other than diammonium phosphate and monoammonium phosphate'";
     }
   | {
       '@level'?: '4';
@@ -5848,7 +5848,7 @@ export type FlowsProductCategory =
   | {
       '@level'?: '2';
       '@classId'?: '351';
-      '#text'?: "Paints and varnishes and related products; artists\' colours; ink";
+      '#text'?: "Paints and varnishes and related products; artists' colours; ink";
     }
   | {
       '@level'?: '3';
@@ -5863,12 +5863,12 @@ export type FlowsProductCategory =
   | {
       '@level'?: '3';
       '@classId'?: '3512';
-      '#text'?: "Artists\', students\' or signboard painters\' colours, modifying tints, amusement colours and the like";
+      '#text'?: "Artists', students' or signboard painters' colours, modifying tints, amusement colours and the like";
     }
   | {
       '@level'?: '4';
       '@classId'?: '35120';
-      '#text'?: "Artists\', students\' or signboard painters\' colours, modifying tints, amusement colours and the like";
+      '#text'?: "Artists', students' or signboard painters' colours, modifying tints, amusement colours and the like";
     }
   | { '@level'?: '3'; '@classId'?: '3513'; '#text'?: 'Printing ink' }
   | { '@level'?: '4'; '@classId'?: '35130'; '#text'?: 'Printing ink' }
@@ -6392,12 +6392,12 @@ export type FlowsProductCategory =
   | {
       '@level'?: '3';
       '@classId'?: '3695';
-      '#text'?: "Builders\' ware of plastics n.e.c.";
+      '#text'?: "Builders' ware of plastics n.e.c.";
     }
   | {
       '@level'?: '4';
       '@classId'?: '36950';
-      '#text'?: "Builders\' ware of plastics n.e.c.";
+      '#text'?: "Builders' ware of plastics n.e.c.";
     }
   | {
       '@level'?: '3';
@@ -7113,12 +7113,12 @@ export type FlowsProductCategory =
   | {
       '@level'?: '3';
       '@classId'?: '3851';
-      '#text'?: "Dolls\' carriages; wheeled toys designed to be ridden by children";
+      '#text'?: "Dolls' carriages; wheeled toys designed to be ridden by children";
     }
   | {
       '@level'?: '4';
       '@classId'?: '38510';
-      '#text'?: "Dolls\' carriages; wheeled toys designed to be ridden by children";
+      '#text'?: "Dolls' carriages; wheeled toys designed to be ridden by children";
     }
   | {
       '@level'?: '3';
@@ -7297,7 +7297,7 @@ export type FlowsProductCategory =
   | {
       '@level'?: '3';
       '@classId'?: '3896';
-      '#text'?: "Paintings, drawings and pastels; original engravings, prints and lithographs; original sculptures and statuary, in any material; postage or revenue stamps, stamp-postmarks, first-day covers, postal stationery (stamped paper) and the like; collections and collectors\' pieces of zoological, botanical, mineralogical, anatomical, historical, ethnographic or numismatic interest; antiques";
+      '#text'?: "Paintings, drawings and pastels; original engravings, prints and lithographs; original sculptures and statuary, in any material; postage or revenue stamps, stamp-postmarks, first-day covers, postal stationery (stamped paper) and the like; collections and collectors' pieces of zoological, botanical, mineralogical, anatomical, historical, ethnographic or numismatic interest; antiques";
     }
   | {
       '@level'?: '4';
@@ -7312,7 +7312,7 @@ export type FlowsProductCategory =
   | {
       '@level'?: '4';
       '@classId'?: '38963';
-      '#text'?: "Collections and collectors\' pieces of zoological, botanical, mineralogical, anatomical, historical, ethnographic or numismatic interest; antiques";
+      '#text'?: "Collections and collectors' pieces of zoological, botanical, mineralogical, anatomical, historical, ethnographic or numismatic interest; antiques";
     }
   | {
       '@level'?: '3';
@@ -7376,12 +7376,12 @@ export type FlowsProductCategory =
   | {
       '@level'?: '3';
       '@classId'?: '3911';
-      '#text'?: "Raw offal, inedible (including pigs\' bristles, horse hair, animal guts, bird skins, feathers, bones and ivory)";
+      '#text'?: "Raw offal, inedible (including pigs' bristles, horse hair, animal guts, bird skins, feathers, bones and ivory)";
     }
   | {
       '@level'?: '4';
       '@classId'?: '39110';
-      '#text'?: "Raw offal, inedible (including pigs\' bristles, horse hair, animal guts, bird skins, feathers, bones and ivory)";
+      '#text'?: "Raw offal, inedible (including pigs' bristles, horse hair, animal guts, bird skins, feathers, bones and ivory)";
     }
   | {
       '@level'?: '3';
@@ -8546,7 +8546,7 @@ export type FlowsProductCategory =
   | {
       '@level'?: '4';
       '@classId'?: '42998';
-      '#text'?: "Ships\' propellers and blades therefor";
+      '#text'?: "Ships' propellers and blades therefor";
     }
   | { '@level'?: '4'; '@classId'?: '42999'; '#text'?: 'Metal goods n.e.c.' }
   | { '@level'?: '1'; '@classId'?: '43'; '#text'?: 'General-purpose machinery' }
@@ -10792,12 +10792,12 @@ export type FlowsProductCategory =
   | {
       '@level'?: '3';
       '@classId'?: '4818';
-      '#text'?: "Medical, surgical, dental or veterinary furniture; barbers\' chairs and similar chairs, having rotating as well as both reclining and elevating movements";
+      '#text'?: "Medical, surgical, dental or veterinary furniture; barbers' chairs and similar chairs, having rotating as well as both reclining and elevating movements";
     }
   | {
       '@level'?: '4';
       '@classId'?: '48180';
-      '#text'?: "Medical, surgical, dental or veterinary furniture; barbers\' chairs and similar chairs, having rotating as well as both reclining and elevating movements";
+      '#text'?: "Medical, surgical, dental or veterinary furniture; barbers' chairs and similar chairs, having rotating as well as both reclining and elevating movements";
     }
   | {
       '@level'?: '2';
@@ -12215,7 +12215,7 @@ export type FlowsProductCategory =
   | {
       '@level'?: '4';
       '@classId'?: '61046';
-      '#text'?: "Wholesale trade services, not on a fee or contract basis, of wickerwork, cork goods, cooper\'s ware and other wooden ware";
+      '#text'?: "Wholesale trade services, not on a fee or contract basis, of wickerwork, cork goods, cooper's ware and other wooden ware";
     }
   | {
       '@level'?: '3';
@@ -12561,7 +12561,7 @@ export type FlowsProductCategory =
   | {
       '@level'?: '4';
       '@classId'?: '62146';
-      '#text'?: "Non-specialized store retail trade services, of wickerwork, cork goods, cooper\'s ware and other wooden ware";
+      '#text'?: "Non-specialized store retail trade services, of wickerwork, cork goods, cooper's ware and other wooden ware";
     }
   | {
       '@level'?: '3';
@@ -12876,7 +12876,7 @@ export type FlowsProductCategory =
   | {
       '@level'?: '4';
       '@classId'?: '62246';
-      '#text'?: "Specialized store retail trade services, of wickerwork, cork goods, cooper\'s ware and other wooden ware";
+      '#text'?: "Specialized store retail trade services, of wickerwork, cork goods, cooper's ware and other wooden ware";
     }
   | {
       '@level'?: '3';
@@ -13191,7 +13191,7 @@ export type FlowsProductCategory =
   | {
       '@level'?: '4';
       '@classId'?: '62346';
-      '#text'?: "Mail order or Internet retail trade services, of wickerwork, cork goods, cooper\'s ware and other wooden ware";
+      '#text'?: "Mail order or Internet retail trade services, of wickerwork, cork goods, cooper's ware and other wooden ware";
     }
   | {
       '@level'?: '3';
@@ -13506,7 +13506,7 @@ export type FlowsProductCategory =
   | {
       '@level'?: '4';
       '@classId'?: '62446';
-      '#text'?: "Other non-store retail trade services, of wickerwork, cork goods, cooper\'s ware and other wooden ware";
+      '#text'?: "Other non-store retail trade services, of wickerwork, cork goods, cooper's ware and other wooden ware";
     }
   | {
       '@level'?: '3';
@@ -18770,12 +18770,12 @@ export type FlowsProductCategory =
   | {
       '@level'?: '3';
       '@classId'?: '9132';
-      '#text'?: "Administrative services related to government employee pension schemes; old-age disability or survivors\' benefit schemes, other than for government employees";
+      '#text'?: "Administrative services related to government employee pension schemes; old-age disability or survivors' benefit schemes, other than for government employees";
     }
   | {
       '@level'?: '4';
       '@classId'?: '91320';
-      '#text'?: "Administrative services related to government employee pension schemes; old-age disability or survivors\' benefit schemes, other than for government employees";
+      '#text'?: "Administrative services related to government employee pension schemes; old-age disability or survivors' benefit schemes, other than for government employees";
     }
   | {
       '@level'?: '3';
@@ -19992,12 +19992,12 @@ export type FlowsProductCategory =
   | {
       '@level'?: '3';
       '@classId'?: '9721';
-      '#text'?: "Hairdressing and barbers\' services";
+      '#text'?: "Hairdressing and barbers' services";
     }
   | {
       '@level'?: '4';
       '@classId'?: '97210';
-      '#text'?: "Hairdressing and barbers\' services";
+      '#text'?: "Hairdressing and barbers' services";
     }
   | {
       '@level'?: '3';

--- a/sdks/typescript/src/types/tidas_processes_category.ts
+++ b/sdks/typescript/src/types/tidas_processes_category.ts
@@ -591,7 +591,7 @@ export type ProcessesCategory =
   | {
       '@level'?: '3';
       '@classId'?: '1622';
-      '#text'?: "Manufacture of builders\' carpentry and joinery";
+      '#text'?: "Manufacture of builders' carpentry and joinery";
     }
   | {
       '@level'?: '3';

--- a/sdks/typescript/src/utils/diff.ts
+++ b/sdks/typescript/src/utils/diff.ts
@@ -68,7 +68,7 @@ export async function saveDiffToFile(
   original: any,
   improved: any,
   outputPath: string,
-  options?: {
+  _options?: {
     title?: string;
     description?: string;
     theme?: 'light' | 'dark';
@@ -103,12 +103,14 @@ export function generateDiffSummary(
 
       if (JSON.stringify(originalValue) !== JSON.stringify(improvedValue)) {
         summary.push(`📝 ${path}:`);
-        const originalStr = originalValue !== undefined 
-          ? JSON.stringify(originalValue, null, 2).substring(0, 100)
-          : 'undefined';
-        const improvedStr = improvedValue !== undefined
-          ? JSON.stringify(improvedValue, null, 2).substring(0, 100)
-          : 'undefined';
+        const originalStr =
+          originalValue !== undefined
+            ? JSON.stringify(originalValue, null, 2).substring(0, 100)
+            : 'undefined';
+        const improvedStr =
+          improvedValue !== undefined
+            ? JSON.stringify(improvedValue, null, 2).substring(0, 100)
+            : 'undefined';
         summary.push(`  Before: ${originalStr}...`);
         summary.push(`  After:  ${improvedStr}...`);
         summary.push('');


### PR DESCRIPTION
Closes tiangong-lca/tidas-sdk#17

## Summary
- Add package-level parity validation APIs under @tiangong-lca/tidas-sdk/parity.
- Verify TypeScript validation behavior against the existing tidas-tools oracle and keep the package lint-clean.
- Update package docs and examples so the new parity layer is consumable from the unified CLI and other TypeScript callers.

## Key Decisions
- Keep format conversion and export parity out of scope while closing the validation gap completely.
- Use generated schemas plus explicit domain rules rather than schema success alone for package-level validation.

## Validation
- ./scripts/ci/verify-typescript-package.sh

## Risks / Rollback
- Low: the new parity APIs are additive and validated by the package-level verification pipeline.

## Follow-ups
- Wire the unified CLI to prefer the local TypeScript parity validator wherever tools-side fallback is no longer required.

## Workspace Integration
- Requires a later lca-workspace submodule bump after merge.