### PR TITLE
chore: sync SDKs from tidas-tools 19d0d16

### DIFF
--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tidas-sdk"
-version = "0.2.2"
+version = "0.2.3"
 description = "Python SDK for TIDAS/ILCD Life Cycle Assessment data"
 authors = [{ name = "Tiangong LCA Team" }]
 license = { text = "MIT" }

--- a/sdks/python/src/tidas_sdk/generated/tidas_lifecyclemodels.py
+++ b/sdks/python/src/tidas_sdk/generated/tidas_lifecyclemodels.py
@@ -147,7 +147,7 @@ class ProcessesProcessInstanceItem(TidasBaseModel):
     scaling_factors: Real | None = Field(default=None, alias='scalingFactors', description='A multiplicative scaling factor for the entire inventory of this process instance, used e.g. to scale the "Reference process" to the aimed-at amount of product (and thereby indirectly the entire inventory of the life cycle model). Note: Care is to be taken that models are not over- or under-specified - note that each process instance scaling is reducing the model\'s degree of freedom by one.')
     groups: ProcessInstanceItemGroups | None = Field(default=None, alias='groups', description='Group(s) to which this process instance belongs.')
     parameters: ProcessInstanceItemParameters | None = Field(default=None, alias='parameters', description='Set of parameters of this process instance with parameter values (changed or unchanged from those in the underlying process data set).')
-    connections: ProcessInstanceItemConnections = Field(default=..., alias='connections', description='Connection information among process instances, via connecting product or waste flow exchanges.')
+    connections: ProcessInstanceItemConnections | None = Field(default=None, alias='connections', description='Connection information among process instances, via connecting product or waste flow exchanges.')
     common_other: str | None = Field(default=None, alias='common:other')
 
 class GroupsMemberOfOption02(TidasBaseModel):
@@ -217,7 +217,7 @@ class ProcessesProcessInstanceOption1(TidasBaseModel):
     scaling_factors: Real | None = Field(default=None, alias='scalingFactors', description='A multiplicative scaling factor for the entire inventory of this process instance, used e.g. to scale the "Reference process" to the aimed-at amount of product (and thereby indirectly the entire inventory of the life cycle model). Note: Care is to be taken that models are not over- or under-specified - note that each process instance scaling is reducing the model\'s degree of freedom by one.')
     groups: ProcessInstanceOption1Groups | None = Field(default=None, alias='groups', description='Group(s) to which this process instance belongs.')
     parameters: ProcessInstanceOption1Parameters | None = Field(default=None, alias='parameters', description='Set of parameters of this process instance with parameter values (changed or unchanged from those in the underlying process data set).')
-    connections: ProcessInstanceOption1Connections = Field(default=..., alias='connections', description='Connection information among process instances, via connecting product or waste flow exchanges.')
+    connections: ProcessInstanceOption1Connections | None = Field(default=None, alias='connections', description='Connection information among process instances, via connecting product or waste flow exchanges.')
     common_other: str | None = Field(default=None, alias='common:other')
 
 class LifeCycleModelInformationTechnologyProcesses(TidasBaseModel):

--- a/sdks/python/src/tidas_sdk/schemas/tidas_lifecyclemodels.json
+++ b/sdks/python/src/tidas_sdk/schemas/tidas_lifecyclemodels.json
@@ -623,8 +623,7 @@
                             "required": [
                             "@dataSetInternalID",
                             "@multiplicationFactor",
-                            "referenceToProcess",
-                            "connections"
+                            "referenceToProcess"
                             ]
                           }
                         },
@@ -924,8 +923,7 @@
                           "required": [
                           "@dataSetInternalID",
                           "@multiplicationFactor",
-                          "referenceToProcess",
-                          "connections"
+                          "referenceToProcess"
                           ]
                         }
                       ]

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tiangong-lca/tidas-sdk",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tiangong-lca/tidas-sdk",
-      "version": "0.1.32",
+      "version": "0.1.33",
       "license": "MIT",
       "dependencies": {
         "@langchain/core": "^0.3.72",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tiangong-lca/tidas-sdk",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "module": "./dist/index.js",

--- a/sdks/typescript/src/runtime-assets/tidas/schemas/tidas_lifecyclemodels.json
+++ b/sdks/typescript/src/runtime-assets/tidas/schemas/tidas_lifecyclemodels.json
@@ -623,8 +623,7 @@
                             "required": [
                             "@dataSetInternalID",
                             "@multiplicationFactor",
-                            "referenceToProcess",
-                            "connections"
+                            "referenceToProcess"
                             ]
                           }
                         },
@@ -924,8 +923,7 @@
                           "required": [
                           "@dataSetInternalID",
                           "@multiplicationFactor",
-                          "referenceToProcess",
-                          "connections"
+                          "referenceToProcess"
                           ]
                         }
                       ]

--- a/sdks/typescript/src/schemas/tidas_lifecyclemodels.schema.ts
+++ b/sdks/typescript/src/schemas/tidas_lifecyclemodels.schema.ts
@@ -132,39 +132,10 @@ export const LifecyclemodelsSchema = z.object({
                         .optional(),
                     })
                     .optional(),
-                  connections: z.object({
-                    outputExchange: z
-                      .union([
-                        z.object({
-                          '@dominant': z
-                            .union([z.literal('true'), z.literal('false')])
-                            .optional(),
-                          '@flowUUID': UUIDSchema,
-                          downstreamProcess: z.union([
-                            z.object({
-                              '@id': z.string(),
-                              '@flowUUID': UUIDSchema,
-                              '@location': z.string().optional(),
-                              '@dominant': z
-                                .union([z.literal('true'), z.literal('false')])
-                                .optional(),
-                            }),
-                            z.array(
-                              z.object({
-                                '@id': z.string(),
-                                '@flowUUID': UUIDSchema,
-                                '@location': z.string().optional(),
-                                '@dominant': z
-                                  .union([
-                                    z.literal('true'),
-                                    z.literal('false'),
-                                  ])
-                                  .optional(),
-                              })
-                            ),
-                          ]),
-                        }),
-                        z.array(
+                  connections: z
+                    .object({
+                      outputExchange: z
+                        .union([
                           z.object({
                             '@dominant': z
                               .union([z.literal('true'), z.literal('false')])
@@ -196,11 +167,45 @@ export const LifecyclemodelsSchema = z.object({
                                 })
                               ),
                             ]),
-                          })
-                        ),
-                      ])
-                      .optional(),
-                  }),
+                          }),
+                          z.array(
+                            z.object({
+                              '@dominant': z
+                                .union([z.literal('true'), z.literal('false')])
+                                .optional(),
+                              '@flowUUID': UUIDSchema,
+                              downstreamProcess: z.union([
+                                z.object({
+                                  '@id': z.string(),
+                                  '@flowUUID': UUIDSchema,
+                                  '@location': z.string().optional(),
+                                  '@dominant': z
+                                    .union([
+                                      z.literal('true'),
+                                      z.literal('false'),
+                                    ])
+                                    .optional(),
+                                }),
+                                z.array(
+                                  z.object({
+                                    '@id': z.string(),
+                                    '@flowUUID': UUIDSchema,
+                                    '@location': z.string().optional(),
+                                    '@dominant': z
+                                      .union([
+                                        z.literal('true'),
+                                        z.literal('false'),
+                                      ])
+                                      .optional(),
+                                  })
+                                ),
+                              ]),
+                            })
+                          ),
+                        ])
+                        .optional(),
+                    })
+                    .optional(),
                   'common:other': z.string().optional(),
                 })
               ),
@@ -243,35 +248,9 @@ export const LifecyclemodelsSchema = z.object({
                       .optional(),
                   })
                   .optional(),
-                connections: z.object({
-                  outputExchange: z.union([
-                    z.object({
-                      '@dominant': z
-                        .union([z.literal('true'), z.literal('false')])
-                        .optional(),
-                      '@flowUUID': UUIDSchema,
-                      downstreamProcess: z.union([
-                        z.object({
-                          '@id': z.string(),
-                          '@flowUUID': UUIDSchema,
-                          '@location': z.string().optional(),
-                          '@dominant': z
-                            .union([z.literal('true'), z.literal('false')])
-                            .optional(),
-                        }),
-                        z.array(
-                          z.object({
-                            '@id': z.string(),
-                            '@flowUUID': UUIDSchema,
-                            '@location': z.string().optional(),
-                            '@dominant': z
-                              .union([z.literal('true'), z.literal('false')])
-                              .optional(),
-                          })
-                        ),
-                      ]),
-                    }),
-                    z.array(
+                connections: z
+                  .object({
+                    outputExchange: z.union([
                       z.object({
                         '@dominant': z
                           .union([z.literal('true'), z.literal('false')])
@@ -297,10 +276,41 @@ export const LifecyclemodelsSchema = z.object({
                             })
                           ),
                         ]),
-                      })
-                    ),
-                  ]),
-                }),
+                      }),
+                      z.array(
+                        z.object({
+                          '@dominant': z
+                            .union([z.literal('true'), z.literal('false')])
+                            .optional(),
+                          '@flowUUID': UUIDSchema,
+                          downstreamProcess: z.union([
+                            z.object({
+                              '@id': z.string(),
+                              '@flowUUID': UUIDSchema,
+                              '@location': z.string().optional(),
+                              '@dominant': z
+                                .union([z.literal('true'), z.literal('false')])
+                                .optional(),
+                            }),
+                            z.array(
+                              z.object({
+                                '@id': z.string(),
+                                '@flowUUID': UUIDSchema,
+                                '@location': z.string().optional(),
+                                '@dominant': z
+                                  .union([
+                                    z.literal('true'),
+                                    z.literal('false'),
+                                  ])
+                                  .optional(),
+                              })
+                            ),
+                          ]),
+                        })
+                      ),
+                    ]),
+                  })
+                  .optional(),
                 'common:other': z.string().optional(),
               }),
             ])

--- a/sdks/typescript/src/types/tidas_lifecyclemodels.ts
+++ b/sdks/typescript/src/types/tidas_lifecyclemodels.ts
@@ -75,7 +75,7 @@ export interface Lifecyclemodels {
                 parameters?: {
                   parameter?: { '@name'?: MatV } | { '@name'?: MatV }[];
                 };
-                connections: {
+                connections?: {
                   outputExchange?:
                     | {
                         '@dominant'?: 'true' | 'false';
@@ -129,7 +129,7 @@ export interface Lifecyclemodels {
                     | { '@name'?: string; parameter?: Real }
                     | { '@name'?: string; parameter?: Real }[];
                 };
-                connections: {
+                connections?: {
                   outputExchange:
                     | {
                         '@dominant'?: 'true' | 'false';


### PR DESCRIPTION
## Summary

- Sync generated SDK artifacts from `tiangong-lca/tidas-tools` commit `19d0d16cb047a533c9cc99f422eebff56e038ee4`.
- Release TypeScript package `@tiangong-lca/tidas-sdk` as `0.1.33` (`patch` bump).
- Release Python package `tidas-sdk` as `0.2.3` (`patch` bump).

## Trigger reason

schema update

## Validation

- `./scripts/ci/verify-typescript-package.sh`
- `./scripts/ci/verify-python-package.sh`