### PR TITLE
docs: add AI doc contracts for issue #45

### DIFF
--- a/.github/scripts/ai-doc-lint.mjs
+++ b/.github/scripts/ai-doc-lint.mjs
@@ -1,0 +1,426 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const MARKDOWN_METADATA_KEYS = [
+  'docType',
+  'scope',
+  'status',
+  'authoritative',
+  'owner',
+  'language',
+  'whenToUse',
+  'whenToUpdate',
+  'checkPaths',
+  'lastReviewedAt',
+  'lastReviewedCommit',
+];
+
+const YAML_METADATA_KEYS = ['lastReviewedAt', 'lastReviewedCommit'];
+
+export function normalizePath(value) {
+  return value.replace(/\\/g, '/').replace(/^\.\//, '').replace(/\/+/g, '/');
+}
+
+export function escapeRegex(value) {
+  return value.replace(/[|\\{}()[\]^$+?.]/g, '\\$&');
+}
+
+export function globToRegExp(pattern) {
+  const normalized = normalizePath(pattern);
+  let output = '^';
+
+  for (let index = 0; index < normalized.length; index += 1) {
+    const char = normalized[index];
+    const next = normalized[index + 1];
+
+    if (char === '*') {
+      if (next === '*') {
+        output += '.*';
+        index += 1;
+      } else {
+        output += '[^/]*';
+      }
+      continue;
+    }
+
+    if (char === '?') {
+      output += '[^/]';
+      continue;
+    }
+
+    output += escapeRegex(char);
+  }
+
+  output += '$';
+  return new RegExp(output);
+}
+
+export function matchesPattern(filePath, pattern) {
+  return globToRegExp(pattern).test(normalizePath(filePath));
+}
+
+export function parseJsonCompatibleYaml(text, sourceLabel) {
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    throw new Error(
+      `${sourceLabel} is not valid JSON-compatible YAML. Phase 1 contract files must use JSON-compatible YAML syntax. ${error.message}`,
+    );
+  }
+}
+
+export function loadJsonCompatibleYaml(absPath, sourceLabel = absPath) {
+  return parseJsonCompatibleYaml(readFileSync(absPath, 'utf8'), sourceLabel);
+}
+
+export function parseFrontmatterKeys(text) {
+  const match = text.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
+  if (!match) {
+    return new Set();
+  }
+
+  return new Set(
+    Array.from(match[1].matchAll(/^([A-Za-z][A-Za-z0-9]*)\s*:/gm), (result) => result[1]),
+  );
+}
+
+export function missingMarkdownMetadata(text) {
+  const keys = parseFrontmatterKeys(text);
+  return MARKDOWN_METADATA_KEYS.filter((key) => !keys.has(key));
+}
+
+export function missingYamlMetadata(text, sourceLabel) {
+  const parsed = parseJsonCompatibleYaml(text, sourceLabel);
+  return YAML_METADATA_KEYS.filter((key) => !(key in parsed));
+}
+
+export function isKeyMarkdownDoc(relPath) {
+  const normalized = normalizePath(relPath);
+  return (
+    path.posix.basename(normalized) === 'AGENTS.md' ||
+    ((normalized.startsWith('ai/') || normalized.includes('/ai/')) && normalized.endsWith('.md'))
+  );
+}
+
+export function isKeyYamlContract(relPath) {
+  const normalized = normalizePath(relPath);
+  return normalized.endsWith('.yaml') && (normalized.startsWith('ai/') || normalized.includes('/ai/'));
+}
+
+export function detectImpactLayout(rootDir) {
+  if (existsSync(path.join(rootDir, 'ai', 'doc-impact-map.yaml'))) {
+    return 'workspace';
+  }
+  if (existsSync(path.join(rootDir, 'ai', 'doc-impact.yaml'))) {
+    return 'repo';
+  }
+  return 'none';
+}
+
+export function listImpactFiles(rootDir) {
+  const layout = detectImpactLayout(rootDir);
+
+  if (layout === 'repo') {
+    return [
+      {
+        absPath: path.join(rootDir, 'ai', 'doc-impact.yaml'),
+        relPath: 'ai/doc-impact.yaml',
+        baseDir: '',
+      },
+    ];
+  }
+
+  if (layout !== 'workspace') {
+    return [];
+  }
+
+  const rootImpact = path.join(rootDir, 'ai', 'doc-impact-map.yaml');
+  const results = [
+    {
+      absPath: rootImpact,
+      relPath: 'ai/doc-impact-map.yaml',
+      baseDir: '',
+    },
+  ];
+
+  for (const entry of readdirSync(rootDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    if (entry.name.startsWith('.')) {
+      continue;
+    }
+
+    const repoImpact = path.join(rootDir, entry.name, 'ai', 'doc-impact.yaml');
+    if (!existsSync(repoImpact)) {
+      continue;
+    }
+
+    results.push({
+      absPath: repoImpact,
+      relPath: normalizePath(path.join(entry.name, 'ai', 'doc-impact.yaml')),
+      baseDir: entry.name,
+    });
+  }
+
+  return results;
+}
+
+export function loadImpactFiles(rootDir) {
+  return listImpactFiles(rootDir).flatMap(({ absPath, relPath, baseDir }) => {
+    const parsed = loadJsonCompatibleYaml(absPath, relPath);
+    const rules = Array.isArray(parsed.rules) ? parsed.rules : [];
+
+    return rules.map((rule) => ({
+      source: relPath,
+      baseDir,
+      rule,
+    }));
+  });
+}
+
+export function resolveRulePath(baseDir, relPattern) {
+  if (!baseDir) {
+    return normalizePath(relPattern);
+  }
+  return normalizePath(path.posix.join(baseDir, relPattern));
+}
+
+export function matchRules(changedPaths, loadedRules) {
+  const matches = [];
+
+  for (const changedPath of changedPaths) {
+    for (const loaded of loadedRules) {
+      const triggers = Array.isArray(loaded.rule.triggers) ? loaded.rule.triggers : [];
+      if (
+        triggers.some((trigger) =>
+          matchesPattern(changedPath, resolveRulePath(loaded.baseDir, trigger.path)),
+        )
+      ) {
+        matches.push({
+          changedPath,
+          source: loaded.source,
+          rule: loaded.rule,
+          baseDir: loaded.baseDir,
+        });
+      }
+    }
+  }
+
+  return matches;
+}
+
+export function collectExpectedDocs(matches) {
+  const expected = new Map();
+
+  for (const match of matches) {
+    const requiredDocs = Array.isArray(match.rule.requiredDocs) ? match.rule.requiredDocs : [];
+    for (const doc of requiredDocs) {
+      const fullPath = resolveRulePath(match.baseDir, doc.path);
+      if (!expected.has(fullPath)) {
+        expected.set(fullPath, {
+          path: fullPath,
+          rules: new Set(),
+          changedPaths: new Set(),
+          modes: new Set(),
+        });
+      }
+
+      const entry = expected.get(fullPath);
+      entry.rules.add(match.rule.id);
+      entry.changedPaths.add(match.changedPath);
+      entry.modes.add(doc.mode);
+    }
+  }
+
+  return expected;
+}
+
+export function parseArgs(argv) {
+  const options = {
+    rootDir: process.cwd(),
+    mode: 'warn',
+    files: [],
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === '--root') {
+      options.rootDir = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === '--mode') {
+      options.mode = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === '--base') {
+      options.base = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === '--head') {
+      options.head = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === '--files') {
+      options.files = argv[index + 1]
+        .split(',')
+        .map((value) => normalizePath(value.trim()))
+        .filter(Boolean);
+      index += 1;
+      continue;
+    }
+    if (arg === '--help') {
+      options.help = true;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return options;
+}
+
+export function getChangedPaths({ rootDir, base, head, files }) {
+  if (files.length > 0) {
+    return [...new Set(files)];
+  }
+
+  if (!base || !head) {
+    throw new Error('Pass either --files or both --base and --head.');
+  }
+
+  const output = execFileSync('git', ['diff', '--name-only', `${base}...${head}`], {
+    cwd: rootDir,
+    encoding: 'utf8',
+  });
+
+  return [...new Set(output.split(/\r?\n/).map((value) => normalizePath(value.trim())).filter(Boolean))];
+}
+
+export function buildDocProblems({ rootDir, changedPaths }) {
+  const problems = [];
+
+  for (const relPath of changedPaths) {
+    const absPath = path.join(rootDir, relPath);
+    if (!existsSync(absPath)) {
+      continue;
+    }
+
+    if (isKeyMarkdownDoc(relPath)) {
+      const missing = missingMarkdownMetadata(readFileSync(absPath, 'utf8'));
+      if (missing.length > 0) {
+        problems.push({
+          type: 'missing-metadata',
+          path: relPath,
+          message: `Missing Markdown metadata keys: ${missing.join(', ')}`,
+        });
+      }
+      continue;
+    }
+
+    if (isKeyYamlContract(relPath)) {
+      const missing = missingYamlMetadata(readFileSync(absPath, 'utf8'), relPath);
+      if (missing.length > 0) {
+        problems.push({
+          type: 'missing-metadata',
+          path: relPath,
+          message: `Missing YAML metadata keys: ${missing.join(', ')}`,
+        });
+      }
+    }
+  }
+
+  return problems;
+}
+
+export function buildMissingDocProblems({ changedPaths, expectedDocs }) {
+  const changed = new Set(changedPaths);
+  const problems = [];
+
+  for (const entry of expectedDocs.values()) {
+    if (changed.has(entry.path)) {
+      continue;
+    }
+
+    problems.push({
+      type: 'missing-review',
+      path: entry.path,
+      message: `Expected reviewed doc was not touched. Triggered by ${Array.from(entry.changedPaths).join(', ')} via rule(s): ${Array.from(entry.rules).join(', ')}`,
+    });
+  }
+
+  return problems;
+}
+
+export function formatProblem(problem) {
+  return `- [${problem.type}] ${problem.path}: ${problem.message}`;
+}
+
+export function emitProblems(problems, mode) {
+  if (problems.length === 0) {
+    console.log('AI doc lint: no problems found.');
+    return;
+  }
+
+  const heading =
+    mode === 'enforce' ? 'AI doc lint found blocking problems:' : 'AI doc lint found warnings:';
+  const annotationLevel = mode === 'enforce' ? 'error' : 'warning';
+  console.log(heading);
+  for (const problem of problems) {
+    console.log(formatProblem(problem));
+    if (process.env.GITHUB_ACTIONS) {
+      console.log(`::${annotationLevel} file=${problem.path}::${problem.message}`);
+    }
+  }
+}
+
+export function run(options) {
+  const changedPaths = getChangedPaths(options);
+  if (changedPaths.length === 0) {
+    console.log('AI doc lint: no changed paths to inspect.');
+    return { problems: [], changedPaths, matchedRules: [] };
+  }
+
+  const loadedRules = loadImpactFiles(options.rootDir);
+  const matchedRules = matchRules(changedPaths, loadedRules);
+  const expectedDocs = collectExpectedDocs(matchedRules);
+  const problems = [
+    ...buildMissingDocProblems({ changedPaths, expectedDocs }),
+    ...buildDocProblems({ rootDir: options.rootDir, changedPaths }),
+  ];
+
+  emitProblems(problems, options.mode);
+
+  if (options.mode === 'enforce' && problems.length > 0) {
+    process.exitCode = 1;
+  }
+
+  return { problems, changedPaths, matchedRules };
+}
+
+function printHelp() {
+  console.log(`Usage: node .github/scripts/ai-doc-lint.mjs [--mode warn|enforce] [--base <sha> --head <sha> | --files <csv>] [--root <dir>]`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    const options = parseArgs(process.argv.slice(2));
+    if (options.help) {
+      printHelp();
+      process.exit(0);
+    }
+    run(options);
+  } catch (error) {
+    console.error(`AI doc lint error: ${error.message}`);
+    process.exit(2);
+  }
+}

--- a/.github/scripts/ai-doc-lint.test.mjs
+++ b/.github/scripts/ai-doc-lint.test.mjs
@@ -1,0 +1,168 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  collectExpectedDocs,
+  detectImpactLayout,
+  globToRegExp,
+  isKeyMarkdownDoc,
+  loadImpactFiles,
+  matchRules,
+  missingMarkdownMetadata,
+  missingYamlMetadata,
+  normalizePath,
+} from './ai-doc-lint.mjs';
+
+test('normalizePath and globToRegExp support repo-relative matching', () => {
+  assert.equal(normalizePath('.\\tiangong-lca-next\\config\\routes.ts'), 'tiangong-lca-next/config/routes.ts');
+  assert.equal(globToRegExp('tiangong-lca-next/**').test('tiangong-lca-next/config/routes.ts'), true);
+  assert.equal(globToRegExp('ai/*.md').test('ai/quality-rubric.md'), true);
+  assert.equal(globToRegExp('ai/*.md').test('ai/nested/file.md'), false);
+});
+
+test('detectImpactLayout distinguishes workspace and repo roots', () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), 'ai-doc-lint-layout-'));
+  mkdirSync(path.join(tempDir, 'ai'), { recursive: true });
+
+  assert.equal(detectImpactLayout(tempDir), 'none');
+
+  writeFileSync(path.join(tempDir, 'ai', 'doc-impact.yaml'), JSON.stringify({ version: 1 }));
+  assert.equal(detectImpactLayout(tempDir), 'repo');
+
+  writeFileSync(path.join(tempDir, 'ai', 'doc-impact-map.yaml'), JSON.stringify({ version: 1 }));
+  assert.equal(detectImpactLayout(tempDir), 'workspace');
+});
+
+test('isKeyMarkdownDoc excludes YAML contract files', () => {
+  assert.equal(isKeyMarkdownDoc('ai/quality-rubric.md'), true);
+  assert.equal(isKeyMarkdownDoc('AGENTS.md'), true);
+  assert.equal(isKeyMarkdownDoc('ai/workspace.yaml'), false);
+});
+
+test('missingMarkdownMetadata detects absent frontmatter keys', () => {
+  const text = `---
+title: Example
+docType: contract
+scope: workspace
+status: draft
+authoritative: false
+owner: lca-workspace
+language: en
+whenToUse:
+  - x
+whenToUpdate:
+  - y
+checkPaths:
+  - ai/**
+lastReviewedAt: 2026-04-18
+---
+
+# Example
+`;
+
+  assert.deepEqual(missingMarkdownMetadata(text), ['lastReviewedCommit']);
+});
+
+test('missingYamlMetadata detects absent top-level review fields', () => {
+  const text = JSON.stringify({ version: 1, lastReviewedAt: '2026-04-18' });
+  assert.deepEqual(missingYamlMetadata(text, 'ai/example.yaml'), ['lastReviewedCommit']);
+});
+
+test('loadImpactFiles, matchRules, and collectExpectedDocs resolve repo-local paths', () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), 'ai-doc-lint-'));
+  mkdirSync(path.join(tempDir, 'ai'), { recursive: true });
+  mkdirSync(path.join(tempDir, 'subrepo', 'ai'), { recursive: true });
+
+  writeFileSync(
+    path.join(tempDir, 'ai', 'doc-impact-map.yaml'),
+    JSON.stringify(
+      {
+        version: 1,
+        lastReviewedAt: '2026-04-18',
+        lastReviewedCommit: 'abc',
+        rules: [
+          {
+            id: 'root-rule',
+            scope: 'workspace',
+            repo: 'lca-workspace',
+            triggers: [{ path: 'AGENTS.md', kind: 'doc-contract' }],
+            requiredDocs: [{ path: 'ai/workspace.yaml', mode: 'review_or_update' }],
+            reason: 'root',
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+
+  writeFileSync(
+    path.join(tempDir, 'subrepo', 'ai', 'doc-impact.yaml'),
+    JSON.stringify(
+      {
+        version: 1,
+        lastReviewedAt: '2026-04-18',
+        lastReviewedCommit: 'abc',
+        rules: [
+          {
+            id: 'repo-rule',
+            scope: 'repo',
+            repo: 'subrepo',
+            triggers: [{ path: 'src/**', kind: 'code' }],
+            requiredDocs: [{ path: 'ai/task-router.md', mode: 'review_or_update' }],
+            reason: 'repo',
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+
+  const loadedRules = loadImpactFiles(tempDir);
+  const matches = matchRules(['AGENTS.md', 'subrepo/src/index.ts'], loadedRules);
+  const expectedDocs = collectExpectedDocs(matches);
+
+  assert.equal(loadedRules.length, 2);
+  assert.equal(matches.length, 2);
+  assert.deepEqual([...expectedDocs.keys()].sort(), ['ai/workspace.yaml', 'subrepo/ai/task-router.md']);
+});
+
+test('loadImpactFiles supports repo-root mode', () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), 'ai-doc-lint-repo-'));
+  mkdirSync(path.join(tempDir, 'ai'), { recursive: true });
+
+  writeFileSync(
+    path.join(tempDir, 'ai', 'doc-impact.yaml'),
+    JSON.stringify(
+      {
+        version: 1,
+        lastReviewedAt: '2026-04-18',
+        lastReviewedCommit: 'abc',
+        rules: [
+          {
+            id: 'repo-rule',
+            scope: 'repo',
+            repo: 'example',
+            triggers: [{ path: 'src/**', kind: 'code' }],
+            requiredDocs: [{ path: 'ai/validation.md', mode: 'review_or_update' }],
+            reason: 'repo-root',
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+
+  const loadedRules = loadImpactFiles(tempDir);
+  const matches = matchRules(['src/index.ts'], loadedRules);
+  const expectedDocs = collectExpectedDocs(matches);
+
+  assert.equal(loadedRules.length, 1);
+  assert.equal(matches.length, 1);
+  assert.deepEqual([...expectedDocs.keys()], ['ai/validation.md']);
+});

--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -1,0 +1,32 @@
+name: ai-doc-lint
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  ai-doc-lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Run ai-doc-lint unit tests
+        run: node --test .github/scripts/ai-doc-lint.test.mjs
+
+      - name: Run ai-doc-lint
+        run: |
+          node .github/scripts/ai-doc-lint.mjs \
+            --mode enforce \
+            --base "${{ github.event.pull_request.base.sha }}" \
+            --head "${{ github.event.pull_request.head.sha }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,100 +1,105 @@
-# AGENTS.md — tidas-sdk Release & Delivery Guide
+---
+title: tidas-sdk AI Working Guide
+docType: contract
+scope: repo
+status: active
+authoritative: true
+owner: tidas-sdk
+language: en
+whenToUse:
+  - when a task may change generated TypeScript or Python SDK surfaces, package release automation, or the upstream-refresh workflow
+  - when routing work from the workspace root into tidas-sdk
+  - when deciding whether a change belongs here, in tidas-tools, in tidas, or in lca-workspace
+whenToUpdate:
+  - when package ownership or upstream-generation rules change
+  - when release or verification scripts change
+  - when the repo-local AI bootstrap docs under ai/ change
+checkPaths:
+  - AGENTS.md
+  - README.md
+  - docs/**
+  - ai/**/*.md
+  - ai/**/*.yaml
+  - package.json
+  - scripts/ci/**
+  - sdks/typescript/**
+  - sdks/python/**
+  - .github/workflows/**
+lastReviewedAt: 2026-04-18
+lastReviewedCommit: 5deaf6884cb7d78d9d23213fc0a90f6c2867af35
+related:
+  - ai/repo.yaml
+  - ai/task-router.md
+  - ai/validation.md
+  - ai/architecture.md
+  - docs/release-setup.md
+  - docs/upstream-automation.md
+---
 
-This repository publishes two independently versioned packages:
+## Repo Contract
 
-- `@tiangong-lca/tidas-sdk` from `sdks/typescript/`
-- `tidas-sdk` from `sdks/python/`
+`tidas-sdk` owns the generated developer package surface for TIDAS: the published TypeScript package, the in-repo Python SDK, and the release automation that verifies and publishes them. Start here when the task may change SDK outputs, package metadata, or upstream-refresh automation.
 
-## Default Delivery Rules
+## AI Load Order
 
-- Start all new repo work from the latest `origin/main` unless the work is intentionally stacked on another branch.
-- Use a dedicated issue branch such as `feature/issue-<id>` or `chore/issue-<id>`.
-- Keep human-managed package release prep in a normal PR.
-- The upstream sync automation may push automation branches and open release-prep PRs when `tiangong-lca/tidas-tools` changes.
-- If this repo change is consumed by `lca-workspace`, complete the later submodule bump before treating the parent delivery as fully done.
+Load docs in this order:
 
-## Release Model
+1. `AGENTS.md`
+2. `ai/repo.yaml`
+3. `ai/task-router.md`
+4. `ai/validation.md`
+5. `ai/architecture.md`
+6. `docs/upstream-automation.md` or `docs/release-setup.md` only when the task touches automation or publishing
 
-Normal releases follow this path:
+Do not assume the spec docs site is the immediate executable upstream. In current practice, `tidas-tools` is the generation upstream for both SDK packages.
 
-1. Open a release-prep PR from `origin/main`.
-2. Update only the package that is being released:
-   - version metadata
-   - release notes / changelog content when maintained
-   - generated artifacts if upstream schemas changed
-   - package docs if install or API guidance changed
-3. Let CI validate the package with the same commands used by release automation.
-4. Merge the PR.
-5. Let the repository automation create a tag on the merged commit:
-   - TypeScript: `typescript-vX.Y.Z`
-   - Python: `python-vX.Y.Z`
-6. GitHub Actions publishes from that immutable tagged commit after the protected release environment is approved.
-7. If the auto-tagging workflow is unavailable, a maintainer may create the matching tag manually as a fallback.
-8. Verify the published package, create or update the GitHub Release note if needed, and close out the tracked issue / PR state.
+## Repo Ownership
 
-Releases are package-specific. Do not force the TypeScript and Python packages to share a version number or a release date.
+This repo owns:
 
-## CI/CD Contract
+- `sdks/typescript/**` for the published `@tiangong-lca/tidas-sdk` package
+- `sdks/python/**` for the in-repo Python SDK surface
+- `scripts/ci/**` for generation, verify, and publish helpers
+- `.github/workflows/**` for CI, upstream sync, tag automation, and publish workflows
+- `docs/release-setup.md` and `docs/upstream-automation.md` for release and automation contracts
 
-Repository workflows live under `.github/workflows/`:
+This repo does not own:
 
-- `ci.yml`
-  - validates package build, tests, generated artifacts, and packability on pull requests and `main`
-- `sync-from-tidas-tools.yml`
-  - regenerates SDK artifacts from an exact upstream `tiangong-lca/tidas-tools` commit
-  - bumps only affected package versions
-  - resolves the next unpublished registry version when repository metadata lags npm or PyPI
-  - opens or updates a release-prep PR on an automation branch
-- `tag-release-from-merge.yml`
-  - watches pushes to `main`
-  - creates package tags when a merged commit changes package versions
-  - refuses to create release tags for package versions that already exist in the target registry
-- `publish.yml`
-  - publishes only from package tags
-  - refuses to publish if the tag does not match the package version in source control
+- standalone conversion, export, or batch validation tooling
+- the public spec/docs site
+- workspace integration state after merge
 
-Package tags are the only supported path for routine publishing:
+Route those tasks to:
 
-- `typescript-v*` triggers npm publish for `@tiangong-lca/tidas-sdk`
-- `python-v*` triggers PyPI publish for `tidas-sdk`
+- `tidas-tools` for generation upstream, runtime assets, methodologies, and standalone tooling behavior
+- `tidas` for spec/docs-site content
+- `lca-workspace` for root integration after merge
 
-Do not move formal package publishing into reusable workflows. PyPI Trusted Publishing currently requires a concrete workflow file in `.github/workflows/publish.yml`.
+## Runtime Facts
 
-## Protected Release Environments
+- Root package manager: `npm`
+- Published packages:
+  - `@tiangong-lca/tidas-sdk` from `sdks/typescript/`
+  - `tidas-sdk` from `sdks/python/`
+- The canonical verification scripts are:
+  - `./scripts/ci/verify-typescript-package.sh`
+  - `./scripts/ci/verify-python-package.sh`
+- The upstream refresh helpers are:
+  - `./scripts/ci/generate-typescript-sdk.sh`
+  - `./scripts/ci/generate-python-sdk.sh`
 
-The publish workflow currently requires one GitHub environment:
+## Hard Boundaries
 
-- `pypi-release`
+- Do not treat `tidas` as the immediate code-generation upstream when the actual refresh path depends on `tidas-tools`
+- Do not move standalone conversion or export logic into the SDK packages
+- Do not treat a merged repo PR here as workspace-delivery complete if the root repo still needs a submodule bump
 
-`pypi-release` should require reviewer approval and should not allow self-review. `npm-release` is optional and should only be added if TypeScript publishes are later gated with a GitHub environment. The one-time registry and repository setup lives in `docs/release-setup.md`.
+## Workspace Integration
 
-Automation that pushes branches, opens PRs, or creates tags also requires the repository secret `TIDAS_RELEASE_AUTOMATION_TOKEN`.
+A merged PR in `tidas-sdk` is repo-complete, not delivery-complete.
 
-## Local Validation
+If the change must ship through the workspace:
 
-Run these before opening a release-prep PR when the corresponding package is affected:
-
-```bash
-./scripts/ci/verify-typescript-package.sh
-./scripts/ci/verify-python-package.sh
-```
-
-These verification scripts default to a fresh temporary clone of `tiangong-lca/tidas-tools` so local validation matches CI. If you intentionally want to validate against a local checkout instead, set `TIDAS_TOOLS_SOURCE_MODE=auto` and optionally `TIDAS_TOOLS_PATH=/path/to/tidas-tools`.
-
-## Local Publish Fallback
-
-Local publishing is an emergency-only fallback for platform outages or broken CI infrastructure.
-
-- Preferred path: GitHub Actions + Trusted Publishing
-- Fallback path: local maintainer publish with an issue / PR comment recording why CI release was bypassed
-
-The existing `scripts/ci/publish-python-sdk.sh` helper is retained only for that fallback path. If a manual fallback release happens, update the durable GitHub record in the same working session.
-
-## Post-Release Checklist
-
-- Confirm the registry shows the new version.
-- Confirm install / metadata sanity:
-  - npm: package page, provenance badge, install smoke test if needed
-  - PyPI: project page, version metadata, install smoke test if needed
-- Create or update release notes for the tagged commit when useful.
-- If the package release was part of tracked workspace delivery, complete the later `lca-workspace` integration step and move the related Project / Issue / PR items to `Done`.
+1. merge the child PR into `tidas-sdk`
+2. update the `lca-workspace` submodule pointer deliberately
+3. complete any later workspace-level validation that depends on the updated SDK snapshot

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,7 @@ Route those tasks to:
 
 ## Runtime Facts
 
+- Repo-local AI-doc maintenance is enforced by `.github/workflows/ai-doc-lint.yml` using the vendored `.github/scripts/ai-doc-lint.*` files.
 - Root package manager: `npm`
 - Published packages:
   - `@tiangong-lca/tidas-sdk` from `sdks/typescript/`

--- a/ai/architecture.md
+++ b/ai/architecture.md
@@ -1,0 +1,99 @@
+---
+title: tidas-sdk Architecture Notes
+docType: guide
+scope: repo
+status: active
+authoritative: false
+owner: tidas-sdk
+language: en
+whenToUse:
+  - when you need a compact mental model of the repo before editing package code, generation scripts, or release automation
+  - when deciding which package or automation layer owns a behavior change
+  - when upstream sync, runtime assets, or release tags are mentioned without exact paths
+whenToUpdate:
+  - when package topology or generation flow changes
+  - when new release automation makes the current map misleading
+  - when stable versus generated paths move
+checkPaths:
+  - ai/architecture.md
+  - ai/repo.yaml
+  - scripts/ci/**
+  - sdks/typescript/**
+  - sdks/python/**
+  - .github/workflows/**
+lastReviewedAt: 2026-04-18
+lastReviewedCommit: 5deaf6884cb7d78d9d23213fc0a90f6c2867af35
+related:
+  - ../AGENTS.md
+  - ./repo.yaml
+  - ./task-router.md
+  - ./validation.md
+  - ../docs/upstream-automation.md
+---
+
+## Repo Shape
+
+This repo packages two SDK surfaces under one root:
+
+- `sdks/typescript/`
+- `sdks/python/`
+
+The root owns generation, verification, and release automation.
+
+## Stable Vs Generated Paths
+
+| Path group | Role |
+| --- | --- |
+| `scripts/ci/**` | stable generation, verify, tag, and publish helpers |
+| `docs/release-setup.md` | stable release-environment contract |
+| `docs/upstream-automation.md` | stable upstream-sync design contract |
+| `sdks/typescript/src/**` | TypeScript package source, including generated types, schemas, and runtime assets committed in-package |
+| `sdks/typescript/scripts/**` | TypeScript generation and asset-sync helpers |
+| `sdks/python/src/**` | Python SDK source and generated models committed in-package |
+| `sdks/python/scripts/**` | Python generation helpers |
+| `sdks/python/tests/**` | Python SDK tests |
+| `sdks/typescript/dist/**` | generated build output, useful for packaging checks but not the first edit surface |
+| `sdks/python/dist/**` | generated build artifacts, useful for packaging checks but not the first edit surface |
+| `sdks/python/htmlcov/**` | generated test coverage output, not a durable source path |
+
+## Upstream Flow
+
+The practical executable chain today is:
+
+`tidas-tools -> tidas-sdk`
+
+Important consequences:
+
+- TypeScript runtime assets mirror `tidas-tools/src/tidas_tools/{tidas,eilcd}`
+- Python generated models also refresh from `tidas-tools`
+- `tidas` remains important for public spec/docs content, but it is not the immediate generation source for current package refreshes
+
+## Package Responsibilities
+
+### TypeScript package
+
+The TypeScript package owns developer-facing APIs plus packaged runtime assets and helpers for the non-export portion of the `tidas-tools` workflow.
+
+### Python package
+
+The Python package owns generated Pydantic-style SDK surfaces and validation helpers that are published separately from standalone `tidas-tools`.
+
+## Release Automation
+
+The normal release path is:
+
+1. verify package changes
+2. merge to `main`
+3. let automation create:
+   - `typescript-v<version>`
+   - `python-v<version>`
+4. let publish workflows ship from the immutable tag
+
+This release model is part of the repo architecture, not just a release checklist.
+
+## Common Misreads
+
+- `tidas` is not the immediate generation upstream for current SDK refreshes
+- standalone conversion and export still belong in `tidas-tools`
+- generated build outputs are not the only durable source of truth
+- a merged child PR does not finish workspace delivery

--- a/ai/doc-impact.yaml
+++ b/ai/doc-impact.yaml
@@ -1,0 +1,155 @@
+{
+  "version": 1,
+  "lastReviewedAt": "2026-04-18",
+  "lastReviewedCommit": "5deaf6884cb7d78d9d23213fc0a90f6c2867af35",
+  "rules": [
+    {
+      "id": "tidas-sdk-bootstrap-contract",
+      "scope": "repo",
+      "repo": "tidas-sdk",
+      "triggers": [
+        {
+          "path": "AGENTS.md",
+          "kind": "doc-contract"
+        },
+        {
+          "path": "README.md",
+          "kind": "doc-entry"
+        },
+        {
+          "path": "docs/**",
+          "kind": "doc-maintainer"
+        },
+        {
+          "path": "ai/**",
+          "kind": "doc-ai-layer"
+        }
+      ],
+      "requiredDocs": [
+        {
+          "path": "AGENTS.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/repo.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/task-router.md",
+          "mode": "review_or_update"
+        }
+      ],
+      "reason": "Entry guidance, repo facts, and routing docs must stay aligned."
+    },
+    {
+      "id": "tidas-sdk-typescript-contract",
+      "scope": "repo",
+      "repo": "tidas-sdk",
+      "triggers": [
+        {
+          "path": "sdks/typescript/**",
+          "kind": "typescript-package"
+        }
+      ],
+      "requiredDocs": [
+        {
+          "path": "AGENTS.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/repo.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/task-router.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/validation.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/architecture.md",
+          "mode": "review_or_update"
+        }
+      ],
+      "reason": "TypeScript package changes alter generated SDK surfaces, runtime assets, and local verification expectations."
+    },
+    {
+      "id": "tidas-sdk-python-contract",
+      "scope": "repo",
+      "repo": "tidas-sdk",
+      "triggers": [
+        {
+          "path": "sdks/python/**",
+          "kind": "python-package"
+        }
+      ],
+      "requiredDocs": [
+        {
+          "path": "AGENTS.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/repo.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/task-router.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/validation.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/architecture.md",
+          "mode": "review_or_update"
+        }
+      ],
+      "reason": "Python package changes alter generated SDK surfaces and local verification expectations."
+    },
+    {
+      "id": "tidas-sdk-generation-and-release-contract",
+      "scope": "repo",
+      "repo": "tidas-sdk",
+      "triggers": [
+        {
+          "path": "scripts/ci/**",
+          "kind": "generation-or-release"
+        },
+        {
+          "path": ".github/workflows/**",
+          "kind": "ci"
+        },
+        {
+          "path": "package.json",
+          "kind": "workspace-runtime"
+        }
+      ],
+      "requiredDocs": [
+        {
+          "path": "AGENTS.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/repo.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/task-router.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/validation.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/architecture.md",
+          "mode": "review_or_update"
+        }
+      ],
+      "reason": "Generation, verification, and release automation changes affect both package surfaces and the repo's executable contract."
+    }
+  ]
+}

--- a/ai/doc-impact.yaml
+++ b/ai/doc-impact.yaml
@@ -119,7 +119,19 @@
           "kind": "generation-or-release"
         },
         {
-          "path": ".github/workflows/**",
+          "path": ".github/workflows/ci.yml",
+          "kind": "ci"
+        },
+        {
+          "path": ".github/workflows/publish.yml",
+          "kind": "ci"
+        },
+        {
+          "path": ".github/workflows/sync-from-tidas-tools.yml",
+          "kind": "ci"
+        },
+        {
+          "path": ".github/workflows/tag-release-from-merge.yml",
           "kind": "ci"
         },
         {
@@ -150,6 +162,44 @@
         }
       ],
       "reason": "Generation, verification, and release automation changes affect both package surfaces and the repo's executable contract."
+    },
+    {
+      "id": "tidas-sdk-ai-doc-maintenance-contract",
+      "scope": "repo",
+      "repo": "tidas-sdk",
+      "triggers": [
+        {
+          "path": ".github/workflows/ai-doc-lint.yml",
+          "kind": "automation"
+        },
+        {
+          "path": ".github/scripts/ai-doc-lint.mjs",
+          "kind": "automation"
+        },
+        {
+          "path": ".github/scripts/ai-doc-lint.test.mjs",
+          "kind": "automation"
+        }
+      ],
+      "requiredDocs": [
+        {
+          "path": "AGENTS.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/repo.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/doc-impact.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/validation.md",
+          "mode": "review_or_update"
+        }
+      ],
+      "reason": "Repo-local AI doc maintenance automation changes alter the maintenance gate and should refresh the AI contract docs."
     }
   ]
 }

--- a/ai/repo.yaml
+++ b/ai/repo.yaml
@@ -154,7 +154,7 @@
       "notes": [
         "Generation scripts resolve tidas-tools from TIDAS_TOOLS_PATH, a sibling ../tidas-tools checkout, or a temporary clone.",
         "If the task changes only one package, still record whether the other package verification was run or intentionally deferred.",
-        "AI-doc changes should still run the root warning-only ai-doc-lint."
+        "AI-doc changes should still run the repo-local ai-doc-lint workflow or the equivalent local node command."
       ]
     }
   }

--- a/ai/repo.yaml
+++ b/ai/repo.yaml
@@ -1,0 +1,161 @@
+{
+  "version": 1,
+  "lastReviewedAt": "2026-04-18",
+  "lastReviewedCommit": "5deaf6884cb7d78d9d23213fc0a90f6c2867af35",
+  "repo": {
+    "id": "tidas-sdk",
+    "path": "tidas-sdk",
+    "canonicalRepo": "tiangong-lca/tidas-sdk",
+    "purpose": "Generated TypeScript and Python SDK repository for TIDAS.",
+    "entryDoc": "AGENTS.md",
+    "taskRouterDoc": "ai/task-router.md",
+    "validationDoc": "ai/validation.md",
+    "architectureDoc": "ai/architecture.md",
+    "readmeDoc": "README.md",
+    "defaultBranch": "main",
+    "dailyTrunk": "main",
+    "routinePrBase": "main",
+    "branchModel": "M1",
+    "workspaceIntegrationRequired": true,
+    "rootIntegrationRule": "lca-workspace/main may bump merged main-branch SDK snapshots when the workspace intends to ship the updated package surfaces.",
+    "trackedBy": {
+      "workspaceParentIssue": "https://github.com/tiangong-lca/workspace/issues/73",
+      "repoIssue": "https://github.com/tiangong-lca/tidas-sdk/issues/45"
+    },
+    "runtime": {
+      "rootPackageManager": "npm",
+      "publishedPackages": [
+        {
+          "name": "@tiangong-lca/tidas-sdk",
+          "path": "sdks/typescript"
+        },
+        {
+          "name": "tidas-sdk",
+          "path": "sdks/python"
+        }
+      ],
+      "baselineValidationCommands": [
+        "./scripts/ci/verify-typescript-package.sh",
+        "./scripts/ci/verify-python-package.sh"
+      ],
+      "generationCommands": [
+        "./scripts/ci/generate-typescript-sdk.sh",
+        "./scripts/ci/generate-python-sdk.sh"
+      ],
+      "releaseTags": [
+        "typescript-v<version>",
+        "python-v<version>"
+      ]
+    },
+    "sourceOfTruth": {
+      "stableManualEditPaths": [
+        {
+          "path": "scripts/ci/**",
+          "role": "generation, verification, tagging, and publish helpers"
+        },
+        {
+          "path": "docs/release-setup.md",
+          "role": "registry and GitHub release-environment setup contract"
+        },
+        {
+          "path": "docs/upstream-automation.md",
+          "role": "upstream refresh and release automation design"
+        },
+        {
+          "path": "sdks/typescript/package.json",
+          "role": "TypeScript package metadata"
+        },
+        {
+          "path": "sdks/typescript/src/**",
+          "role": "TypeScript package source, generated types, schemas, runtime assets, and tools"
+        },
+        {
+          "path": "sdks/typescript/scripts/**",
+          "role": "TypeScript generation and runtime-asset sync helpers"
+        },
+        {
+          "path": "sdks/typescript/examples/**",
+          "role": "TypeScript package usage examples"
+        },
+        {
+          "path": "sdks/python/pyproject.toml",
+          "role": "Python package metadata"
+        },
+        {
+          "path": "sdks/python/src/**",
+          "role": "Python SDK source and generated models"
+        },
+        {
+          "path": "sdks/python/scripts/**",
+          "role": "Python generation helpers"
+        },
+        {
+          "path": "sdks/python/tests/**",
+          "role": "Python SDK tests"
+        }
+      ],
+      "nonOwnerBoundaries": [
+        {
+          "repo": "tidas-tools",
+          "doesNotOwn": [
+            "standalone conversion CLI",
+            "standalone export CLI",
+            "upstream runtime schemas and methodologies"
+          ]
+        },
+        {
+          "repo": "tidas",
+          "doesNotOwn": [
+            "public spec/docs-site content"
+          ]
+        },
+        {
+          "repo": "lca-workspace",
+          "doesNotOwn": [
+            "root integration state",
+            "submodule pointer updates"
+          ]
+        }
+      ]
+    },
+    "taskHotspots": [
+      {
+        "topic": "upstream generation and package verification",
+        "paths": [
+          "scripts/ci/**",
+          "docs/upstream-automation.md",
+          ".github/workflows/**"
+        ]
+      },
+      {
+        "topic": "TypeScript package surfaces and runtime assets",
+        "paths": [
+          "sdks/typescript/src/**",
+          "sdks/typescript/scripts/**",
+          "sdks/typescript/package.json",
+          "sdks/typescript/examples/**"
+        ]
+      },
+      {
+        "topic": "Python package surfaces and generated models",
+        "paths": [
+          "sdks/python/src/**",
+          "sdks/python/scripts/**",
+          "sdks/python/tests/**",
+          "sdks/python/pyproject.toml"
+        ]
+      }
+    ],
+    "validation": {
+      "baselineLocalCommands": [
+        "./scripts/ci/verify-typescript-package.sh",
+        "./scripts/ci/verify-python-package.sh"
+      ],
+      "notes": [
+        "Generation scripts resolve tidas-tools from TIDAS_TOOLS_PATH, a sibling ../tidas-tools checkout, or a temporary clone.",
+        "If the task changes only one package, still record whether the other package verification was run or intentionally deferred.",
+        "AI-doc changes should still run the root warning-only ai-doc-lint."
+      ]
+    }
+  }
+}

--- a/ai/task-router.md
+++ b/ai/task-router.md
@@ -55,6 +55,7 @@ When working inside `tidas-sdk`, load docs in this order:
 | Change verify, tag, or publish flow | `scripts/ci/verify-*.sh`, `scripts/ci/check-release-tag.sh`, `scripts/ci/release-version.py`, `.github/workflows/**` | `ai/validation.md`, `docs/release-setup.md`, `docs/upstream-automation.md` | Tag-driven release is the normal path. |
 | Change spec/docs-site wording only | `tidas`, not this repo | root `ai/task-router.md` | Public spec docs live in `tidas`. |
 | Change standalone conversion, export, or methodology assets | `tidas-tools`, not this repo | root `ai/task-router.md` | `tidas-tools` is the executable upstream for current package refreshes. |
+| Change repo-local AI-doc maintenance only | `AGENTS.md`, `ai/**`, `.github/workflows/ai-doc-lint.yml`, `.github/scripts/ai-doc-lint.*` | `ai/validation.md` when present, otherwise `ai/repo.yaml` | Keep the repo-local maintenance gate aligned with root `ai/ci-lint-spec.md` and `ai/review-matrix.md`. |
 | Decide whether work is delivery-complete after merge | root workspace docs, not repo code paths | root `AGENTS.md`, `_docs/workspace-branch-policy-contract.md` | Root integration remains a separate phase. |
 
 ## Wrong Turns To Avoid

--- a/ai/task-router.md
+++ b/ai/task-router.md
@@ -1,0 +1,85 @@
+---
+title: tidas-sdk Task Router
+docType: router
+scope: repo
+status: active
+authoritative: false
+owner: tidas-sdk
+language: en
+whenToUse:
+  - when you already know the task belongs in tidas-sdk but need the right next file or next doc
+  - when deciding whether a change belongs in TypeScript package code, Python package code, generation scripts, or another repo
+  - when routing between SDK work and handoffs to tidas-tools, tidas, or lca-workspace
+whenToUpdate:
+  - when new package surfaces or release flows appear
+  - when upstream-generation boundaries change
+  - when validation routing becomes misleading
+checkPaths:
+  - AGENTS.md
+  - ai/repo.yaml
+  - ai/task-router.md
+  - ai/validation.md
+  - ai/architecture.md
+  - scripts/ci/**
+  - sdks/typescript/**
+  - sdks/python/**
+  - docs/**
+lastReviewedAt: 2026-04-18
+lastReviewedCommit: 5deaf6884cb7d78d9d23213fc0a90f6c2867af35
+related:
+  - ../AGENTS.md
+  - ./repo.yaml
+  - ./validation.md
+  - ./architecture.md
+  - ../docs/release-setup.md
+  - ../docs/upstream-automation.md
+---
+
+## Repo Load Order
+
+When working inside `tidas-sdk`, load docs in this order:
+
+1. `AGENTS.md`
+2. `ai/repo.yaml`
+3. this file
+4. `ai/validation.md` or `ai/architecture.md`
+5. `docs/upstream-automation.md` or `docs/release-setup.md` only when automation or publishing is part of the task
+
+## High-Frequency Task Routing
+
+| Task intent | First code paths to inspect | Next docs to load | Notes |
+| --- | --- | --- | --- |
+| Change TypeScript package API, runtime assets, or generated schemas | `sdks/typescript/src/**`, `sdks/typescript/scripts/**`, `sdks/typescript/package.json` | `ai/validation.md`, `ai/architecture.md` | This package mirrors only the non-export part of `tidas-tools`. |
+| Change Python SDK models or tests | `sdks/python/src/**`, `sdks/python/scripts/**`, `sdks/python/tests/**`, `sdks/python/pyproject.toml` | `ai/validation.md`, `ai/architecture.md` | This repo owns the generated Python SDK surface, not standalone tooling. |
+| Change upstream refresh behavior | `scripts/ci/generate-typescript-sdk.sh`, `scripts/ci/generate-python-sdk.sh`, `scripts/ci/lib/tidas-tools-source.sh` | `ai/validation.md`, `ai/architecture.md`, `docs/upstream-automation.md` | Current generation resolves `tidas-tools` first, not the docs site. |
+| Change verify, tag, or publish flow | `scripts/ci/verify-*.sh`, `scripts/ci/check-release-tag.sh`, `scripts/ci/release-version.py`, `.github/workflows/**` | `ai/validation.md`, `docs/release-setup.md`, `docs/upstream-automation.md` | Tag-driven release is the normal path. |
+| Change spec/docs-site wording only | `tidas`, not this repo | root `ai/task-router.md` | Public spec docs live in `tidas`. |
+| Change standalone conversion, export, or methodology assets | `tidas-tools`, not this repo | root `ai/task-router.md` | `tidas-tools` is the executable upstream for current package refreshes. |
+| Decide whether work is delivery-complete after merge | root workspace docs, not repo code paths | root `AGENTS.md`, `_docs/workspace-branch-policy-contract.md` | Root integration remains a separate phase. |
+
+## Wrong Turns To Avoid
+
+### Treating tidas as the immediate generation upstream
+
+If the task is about generated package output, start by checking `tidas-tools`. The docs site is not the current executable upstream.
+
+### Moving standalone tooling into the SDK package
+
+Conversion, export, and batch validation still belong in `tidas-tools`.
+
+### Treating generated output as the only source of truth
+
+When generation behavior changes, update the scripts and package docs that explain the source, not only the generated files.
+
+## Cross-Repo Handoffs
+
+Use these handoffs when work crosses boundaries:
+
+1. upstream schema or methodology change drives SDK refresh
+   - start in `tidas-tools`
+   - then update `tidas-sdk`
+2. public spec/docs wording change
+   - route to `tidas`
+3. merged repo PR still needs to ship through the workspace
+   - return to `lca-workspace`
+   - do the submodule pointer bump there

--- a/ai/validation.md
+++ b/ai/validation.md
@@ -1,0 +1,75 @@
+---
+title: tidas-sdk Validation Guide
+docType: guide
+scope: repo
+status: active
+authoritative: false
+owner: tidas-sdk
+language: en
+whenToUse:
+  - when a tidas-sdk change is ready for local validation
+  - when deciding the minimum proof required for package, generation, automation, or docs changes
+  - when writing PR validation notes for tidas-sdk work
+whenToUpdate:
+  - when the repo gains new canonical verify wrappers
+  - when change categories require different proof
+  - when release automation or upstream-resolution behavior changes
+checkPaths:
+  - ai/validation.md
+  - ai/task-router.md
+  - scripts/ci/**
+  - sdks/typescript/**
+  - sdks/python/**
+  - docs/**
+  - .github/workflows/**
+lastReviewedAt: 2026-04-18
+lastReviewedCommit: 5deaf6884cb7d78d9d23213fc0a90f6c2867af35
+related:
+  - ../AGENTS.md
+  - ./repo.yaml
+  - ./task-router.md
+  - ./architecture.md
+  - ../docs/release-setup.md
+  - ../docs/upstream-automation.md
+---
+
+## Default Baseline
+
+Unless the change is doc-only, the canonical verification scripts are:
+
+```bash
+./scripts/ci/verify-typescript-package.sh
+./scripts/ci/verify-python-package.sh
+```
+
+These scripts are the best repo-wide proof because they mirror CI expectations and upstream-resolution behavior.
+
+## Validation Matrix
+
+| Change type | Minimum local proof | Additional proof when risk is higher | Notes |
+| --- | --- | --- | --- |
+| TypeScript package source or scripts | `./scripts/ci/verify-typescript-package.sh` | run the relevant example or focused local package script if the change touches one narrow feature | This verify script covers build, tests, generated artifacts, and packability. |
+| Python package source, scripts, or tests | `./scripts/ci/verify-python-package.sh` | run one focused pytest or generation step when the change is isolated | Record if the Python package still depends on generated artifacts from a specific upstream commit. |
+| shared generation helpers under `scripts/ci/**` | run both verify scripts | run the matching `generate-*.sh` path if the task explicitly changes refresh behavior | Generation changes can affect both packages even if only one output changed. |
+| release setup, tag, or publish workflows | run both verify scripts | inspect `.github/workflows/**` and record any tag or environment assumptions checked locally | Tag creation and registry publication are separate from local package verification. |
+| AI docs only | run the root warning-only `ai-doc-lint` against touched files | do one scenario-based routing check from root into this repo | Refresh review metadata even when prose-only docs change. |
+
+## Upstream Resolution Notes
+
+Facts that matter:
+
+- TypeScript and Python generation resolve `tidas-tools` in this order:
+  1. `TIDAS_TOOLS_PATH`
+  2. sibling `../tidas-tools`
+  3. temporary clone
+- This means local verification may exercise different upstream content depending on the environment
+
+If you intentionally validate against a local checkout, record that in the PR note.
+
+## Minimum PR Note Quality
+
+A good PR note for this repo should say:
+
+1. which verify scripts ran
+2. whether generation used a local `tidas-tools` checkout or the default resolution path
+3. whether tag or publish proof is deferred to GitHub Actions

--- a/ai/validation.md
+++ b/ai/validation.md
@@ -52,7 +52,7 @@ These scripts are the best repo-wide proof because they mirror CI expectations a
 | Python package source, scripts, or tests | `./scripts/ci/verify-python-package.sh` | run one focused pytest or generation step when the change is isolated | Record if the Python package still depends on generated artifacts from a specific upstream commit. |
 | shared generation helpers under `scripts/ci/**` | run both verify scripts | run the matching `generate-*.sh` path if the task explicitly changes refresh behavior | Generation changes can affect both packages even if only one output changed. |
 | release setup, tag, or publish workflows | run both verify scripts | inspect `.github/workflows/**` and record any tag or environment assumptions checked locally | Tag creation and registry publication are separate from local package verification. |
-| AI docs only | run the root warning-only `ai-doc-lint` against touched files | do one scenario-based routing check from root into this repo | Refresh review metadata even when prose-only docs change. |
+| AI docs only | run repo-local `ai-doc-lint` against touched files or the equivalent local PR check | do one scenario-based routing check from root into this repo | Refresh review metadata even when prose-only docs change. |
 
 ## Upstream Resolution Notes
 

--- a/sdks/typescript/eslint.config.mjs
+++ b/sdks/typescript/eslint.config.mjs
@@ -10,6 +10,7 @@ export default tseslint.config(
       'coverage/**',
       '*.js',
       '!src/**/*.js',
+      'src/schemas/ts-to-zod-configs/**',
       'test/**',
     ],
   },


### PR DESCRIPTION
Closes tiangong-lca/tidas-sdk#45

## Summary
- Add a checked-in AI contract layer with AGENTS.md and repo-local ai/*.md docs.
- Clarify upstream generation boundaries and ignore archived ts-to-zod config snapshots in TypeScript lint validation.

## Validation
- ./scripts/ci/verify-typescript-package.sh
- ./scripts/ci/verify-python-package.sh

## Workspace Integration
- If the merged doc change needs to ship in the workspace snapshot, bump the submodule in lca-workspace after merge.