### PR TITLE
Upgrade docpact CI pin to 0.1.4

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: 2026-04-24
-lastReviewedCommit: bd4958bcc4e0e3dd271abb86f5037d32b6fd4d5a
+lastReviewedAt: "2026-04-24"
+lastReviewedCommit: "b87ff191df5655e61a8e151bbc674c0855e53710"
 
 catalog:
   repos:

--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -20,7 +20,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install docpact
-        run: cargo install docpact --version 0.1.2 --force
+        run: cargo install docpact --version 0.1.4 --force
 
       - name: Validate docpact config
         run: docpact validate-config --root . --strict

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ checkPaths:
   - sdks/python/**
   - .github/workflows/**
 lastReviewedAt: 2026-04-24
-lastReviewedCommit: bd4958bcc4e0e3dd271abb86f5037d32b6fd4d5a
+lastReviewedCommit: b87ff191df5655e61a8e151bbc674c0855e53710
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -22,7 +22,7 @@ checkPaths:
   - sdks/python/**
   - .github/workflows/**
 lastReviewedAt: 2026-04-24
-lastReviewedCommit: bd4958bcc4e0e3dd271abb86f5037d32b6fd4d5a
+lastReviewedCommit: b87ff191df5655e61a8e151bbc674c0855e53710
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -24,7 +24,7 @@ checkPaths:
   - docs/upstream-automation.md
   - .github/workflows/**
 lastReviewedAt: 2026-04-24
-lastReviewedCommit: bd4958bcc4e0e3dd271abb86f5037d32b6fd4d5a
+lastReviewedCommit: b87ff191df5655e61a8e151bbc674c0855e53710
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml


### PR DESCRIPTION
Closes #51

## Summary
- Upgrade .github/workflows/ai-doc-lint.yml from docpact 0.1.2 to 0.1.4.
- Preserve the existing ai-doc-lint workflow/check name and command shape.
- Refresh governed doc review metadata required by the repo-local docpact rules for workflow changes.

## Key Decisions
- Do not change runtime code, package versions, release automation, or root workspace submodule pointers.

## Validation
- docpact validate-config --root . --strict with docpact 0.1.4.
- docpact lint --root . --worktree --mode enforce with docpact 0.1.4.
- docpact lint --root . --base origin/main --head HEAD --mode enforce with docpact 0.1.4.

## Risks / Rollback
- Root workspace integration remains pending until this child PR merges and the submodule pointer is deliberately bumped.

## Workspace Integration
- Part of tiangong-lca/workspace#77; child issue keeps Workspace Integration Pending.