### PR TITLE
Prepare SDK package release

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-04-30"
-lastReviewedCommit: "cda3fc26524f4c9e2636ff14c00528b3e7503620"
+lastReviewedAt: "2026-05-03"
+lastReviewedCommit: "9ee586e8401d726fe81402c09e7bffaa3b4aad2c"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,8 +26,8 @@ checkPaths:
   - sdks/typescript/**
   - sdks/python/**
   - .github/workflows/**
-lastReviewedAt: 2026-04-30
-lastReviewedCommit: cda3fc26524f4c9e2636ff14c00528b3e7503620
+lastReviewedAt: 2026-05-03
+lastReviewedCommit: 9ee586e8401d726fe81402c09e7bffaa3b4aad2c
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -21,8 +21,8 @@ checkPaths:
   - sdks/typescript/**
   - sdks/python/**
   - .github/workflows/**
-lastReviewedAt: 2026-04-30
-lastReviewedCommit: cda3fc26524f4c9e2636ff14c00528b3e7503620
+lastReviewedAt: 2026-05-03
+lastReviewedCommit: 9ee586e8401d726fe81402c09e7bffaa3b4aad2c
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -23,8 +23,8 @@ checkPaths:
   - docs/release-setup.md
   - docs/upstream-automation.md
   - .github/workflows/**
-lastReviewedAt: 2026-04-30
-lastReviewedCommit: cda3fc26524f4c9e2636ff14c00528b3e7503620
+lastReviewedAt: 2026-05-03
+lastReviewedCommit: 9ee586e8401d726fe81402c09e7bffaa3b4aad2c
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -16,8 +16,8 @@ checkPaths:
   - .github/workflows/publish.yml
   - .github/workflows/tag-release-from-merge.yml
   - .docpact/config.yaml
-lastReviewedAt: 2026-04-30
-lastReviewedCommit: 53c53416458a4c850d50521ef3db35db23b6c85f
+lastReviewedAt: 2026-05-03
+lastReviewedCommit: 9ee586e8401d726fe81402c09e7bffaa3b4aad2c
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/upstream-automation.md
+++ b/docs/upstream-automation.md
@@ -17,8 +17,8 @@ checkPaths:
   - .github/workflows/sync-from-tidas-tools.yml
   - .github/workflows/tag-release-from-merge.yml
   - .docpact/config.yaml
-lastReviewedAt: 2026-04-30
-lastReviewedCommit: cda3fc26524f4c9e2636ff14c00528b3e7503620
+lastReviewedAt: 2026-05-03
+lastReviewedCommit: 9ee586e8401d726fe81402c09e7bffaa3b4aad2c
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tidas-sdk"
-version = "0.2.4"
+version = "0.2.5"
 description = "Python SDK for TIDAS/ILCD Life Cycle Assessment data"
 authors = [{ name = "Tiangong LCA Team" }]
 license = { text = "MIT" }

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tiangong-lca/tidas-sdk",
-  "version": "0.1.35",
+  "version": "0.1.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tiangong-lca/tidas-sdk",
-      "version": "0.1.35",
+      "version": "0.1.36",
       "license": "MIT",
       "dependencies": {
         "@langchain/core": "^0.3.72",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tiangong-lca/tidas-sdk",
-  "version": "0.1.35",
+  "version": "0.1.36",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "module": "./dist/index.js",


### PR DESCRIPTION
Closes #56

## Summary

- Prepare release metadata for the latest SDK-facing changes already merged on `main`.
- Bump TypeScript package `@tiangong-lca/tidas-sdk` from `0.1.35` to `0.1.36`.
- Bump Python package `tidas-sdk` from `0.2.4` to `0.2.5`.
- Record docpact review evidence for the package/release governance docs required by the TypeScript and Python package contracts.

## Key Decisions

- Use patch releases because the unreleased changes after the latest package tags are schema/generated-surface fixes rather than an intentional breaking release.
- Do not regenerate or alter SDK behavior in this PR; generated SDK changes are already on `main` from prior merged work.
- Let the existing `tag-release-from-merge.yml` workflow create `typescript-v0.1.36` and `python-v0.2.5` after merge, which then drives the tag-based publish workflow.

## Validation

- `python3 scripts/ci/release-version.py assert-unpublished --package typescript --version 0.1.36`
- `python3 scripts/ci/release-version.py assert-unpublished --package python --version 0.2.5`
- `PATH="$HOME/.nvm/versions/node/v24.13.0/bin:$PATH" ./scripts/ci/verify-typescript-package.sh`
- `./scripts/ci/verify-python-package.sh`
- `python3 scripts/ci/detect-release-changes.py --base-ref origin/main --head-ref HEAD`
- `docpact lint --root . --base origin/main --head HEAD --mode enforce`
- `docpact validate-config --root . --strict`

## Risks / Rollback

- Low-risk release metadata PR. If release tagging or publishing behaves unexpectedly, revert the version bump commit before merging or delete the generated tags before publish completes.

## Workspace Integration

- Repo merge and package publishing are not workspace-delivery complete by themselves.
- If this SDK snapshot should ship through `lca-workspace`, update the root submodule pointer separately after release completion.