### PR TITLE
docs: hide README metadata from public landing page

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -250,11 +250,9 @@ rules:
         kind: repo-landing
     requiredDocs:
       - path: AGENTS.md
-        mode: review_or_update
-      - path: README.md
-        mode: review_or_update
+        mode: must_exist
       - path: .docpact/config.yaml
-        mode: review_or_update
+        mode: must_exist
     reason: Repo landing text should stay aligned with the current contract and AI entry surface.
   - id: tidas-sdk-typescript-package-contract
     scope: repo

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,8 +26,8 @@ checkPaths:
   - sdks/typescript/**
   - sdks/python/**
   - .github/workflows/**
-lastReviewedAt: 2026-05-03
-lastReviewedCommit: 9ee586e8401d726fe81402c09e7bffaa3b4aad2c
+lastReviewedAt: 2026-05-06
+lastReviewedCommit: 644631323d7d2e104d68460291234a24cd79c369
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/README.md
+++ b/README.md
@@ -1,39 +1,3 @@
----
-title: tidas-sdk README
-docType: guide
-scope: repo
-status: active
-authoritative: false
-owner: tidas-sdk
-language: en
-whenToUse:
-  - when you need the repo landing context, package overview, or basic setup commands
-  - when deciding which retained AI docs to read next inside tidas-sdk
-whenToUpdate:
-  - when package overview, setup commands, or release guidance changes
-  - when the retained AI docs entry surface changes
-checkPaths:
-  - README.md
-  - AGENTS.md
-  - .docpact/config.yaml
-  - docs/agents/**
-  - docs/release-setup.md
-  - docs/upstream-automation.md
-  - package.json
-  - scripts/ci/**
-  - sdks/typescript/**
-  - sdks/python/**
-lastReviewedAt: 2026-04-23
-lastReviewedCommit: c146296931a18042dfa7f8e433c2ff2b35438601
-related:
-  - AGENTS.md
-  - .docpact/config.yaml
-  - docs/agents/repo-validation.md
-  - docs/agents/repo-architecture.md
-  - docs/release-setup.md
-  - docs/upstream-automation.md
----
-
 # TIDAS SDKs
 
 A multi-language SDK repository for TIDAS (TianGong Life Cycle Assessment data format), providing the generated TypeScript package, the in-repo Python SDK, and the automation that refreshes and releases them from `tidas-tools`.

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -21,8 +21,8 @@ checkPaths:
   - sdks/typescript/**
   - sdks/python/**
   - .github/workflows/**
-lastReviewedAt: 2026-05-03
-lastReviewedCommit: 9ee586e8401d726fe81402c09e7bffaa3b4aad2c
+lastReviewedAt: 2026-05-06
+lastReviewedCommit: 644631323d7d2e104d68460291234a24cd79c369
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -23,8 +23,8 @@ checkPaths:
   - docs/release-setup.md
   - docs/upstream-automation.md
   - .github/workflows/**
-lastReviewedAt: 2026-05-03
-lastReviewedCommit: 9ee586e8401d726fe81402c09e7bffaa3b4aad2c
+lastReviewedAt: 2026-05-06
+lastReviewedCommit: 644631323d7d2e104d68460291234a24cd79c369
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml


### PR DESCRIPTION
Closes #58

## Summary
- Remove visible YAML front matter from the root README so GitHub renders the public landing page from the heading.
- Adjust the README landing docpact rule to keep README changes covered without requiring README.md to carry governance metadata.
- Refresh review metadata on the repo entry/governance docs required by the docpact rule change.

## Key Decisions
- README landing rules now use must_exist checks for AGENTS.md and .docpact/config.yaml instead of review_or_update on README.md.

## Validation
- docpact validate-config --strict
- docpact lint --merge-base <target-base> --mode enforce

## Risks / Rollback
- Low-risk docs/governance change; rollback is restoring the prior README front matter and rule modes.

## Workspace Integration
- After merge, lca-workspace should bump the submodule pointer for this repo.