### PR TITLE
chore: standardize docpact CLI wrapper

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -72,6 +72,7 @@ ownership:
       paths:
         include:
           - .githooks/**
+          - scripts/docpact
           - scripts/docpact-gate.sh
           - scripts/install-git-hooks.sh
       ownerRepo: tidas-sdk
@@ -79,6 +80,7 @@ ownership:
 coverage:
   include:
     - .githooks/**
+    - scripts/docpact
     - scripts/docpact-gate.sh
     - scripts/install-git-hooks.sh
     - AGENTS.md
@@ -139,6 +141,7 @@ routing:
     local-docpact-gate:
       paths:
         - .githooks/pre-push
+        - scripts/docpact
         - scripts/docpact-gate.sh
         - scripts/install-git-hooks.sh
     typescript-sdk:
@@ -416,6 +419,8 @@ rules:
     triggers:
       - path: .githooks/pre-push
         kind: local-git-hook
+      - path: scripts/docpact
+        kind: local-automation
       - path: scripts/docpact-gate.sh
         kind: local-automation
       - path: scripts/install-git-hooks.sh

--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -20,14 +20,14 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install docpact
-        run: cargo install docpact --version 0.1.4 --force
+        run: cargo install docpact --version 0.1.9 --force
 
       - name: Validate docpact config
-        run: docpact validate-config --root . --strict
+        run: scripts/docpact validate-config --root . --strict
 
       - name: Run docpact lint
         run: >
-          docpact lint
+          scripts/docpact lint
           --root .
           --base "${{ github.event.pull_request.base.sha }}"
           --head "${{ github.event.pull_request.head.sha }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ checkPaths:
   - sdks/python/**
   - .github/workflows/**
   - .githooks/**
+  - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-19
@@ -176,4 +177,4 @@ Install the versioned local hook once per checkout:
 ./scripts/install-git-hooks.sh
 ```
 
-The `pre-push` hook runs `scripts/docpact-gate.sh`, which performs strict config validation and `docpact lint --mode enforce` before the push leaves the machine. The default comparison base is `origin/main`. Override it for unusual stacks with `DOCPACT_BASE_REF=<ref>` or `scripts/docpact-gate.sh --base <ref>`. The gate writes its detailed report to a temporary file so normal pushes do not create `.docpact/runs/` artifacts.
+The `pre-push` hook runs `scripts/docpact-gate.sh`, which delegates CLI lookup to `scripts/docpact` and performs strict config validation plus enforced lint before the push leaves the machine. The wrapper checks `DOCPACT_BIN`, Cargo install locations, Homebrew install locations, and then `PATH`, so local agent shells should not fail only because bare `docpact` is unavailable. The default comparison base is `origin/main`. Override it for unusual stacks with `DOCPACT_BASE_REF=<ref>` or `scripts/docpact-gate.sh --base <ref>`. The gate writes its detailed report to a temporary file so normal pushes do not create `.docpact/runs/` artifacts.

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -22,6 +22,7 @@ checkPaths:
   - sdks/python/**
   - .github/workflows/**
   - .githooks/pre-push
+  - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-19
@@ -109,4 +110,4 @@ This release model is part of the repo architecture, not just a release checklis
 
 ## Local Docpact Push Gate
 
-This repository has a versioned local `pre-push` hook under `.githooks/pre-push` that delegates to `scripts/docpact-gate.sh`. The hook is a local developer guard for docpact config validation and enforced doc-governance linting; CI remains the authoritative PR enforcement path.
+This repository has a versioned local `pre-push` hook under `.githooks/pre-push` that delegates to `scripts/docpact-gate.sh`. The gate resolves the CLI through `scripts/docpact`, so local agent shells do not need bare `docpact` on `PATH`. The hook is a local developer guard for docpact config validation and enforced doc-governance linting; CI remains the authoritative PR enforcement path.

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -24,6 +24,7 @@ checkPaths:
   - docs/upstream-automation.md
   - .github/workflows/**
   - .githooks/pre-push
+  - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-19
@@ -55,7 +56,7 @@ These scripts are the best repo-wide proof because they mirror CI expectations a
 | Python package source, scripts, or tests | `./scripts/ci/verify-python-package.sh` | run one focused pytest or generation step when the change is isolated | Record if the Python package still depends on generated artifacts from a specific upstream commit. |
 | shared generation helpers under `scripts/ci/**` | run both verify scripts | run the matching `generate-*.sh` path if the task explicitly changes refresh behavior | Generation changes can affect both packages even if only one output changed. |
 | release setup, tag, or publish workflows | run both verify scripts | inspect `.github/workflows/**` and record any tag or environment assumptions checked locally | Tag creation and registry publication are separate from local package verification. |
-| repo contract or governed-doc changes only | `docpact validate-config --root . --strict` and `docpact lint --root . --staged --mode enforce` | run one focused route check such as `docpact route --root . --intent repo-docs --format text` or `upstream-refresh` when the change touches release / automation docs | Refresh review evidence even when prose-only governed docs change. |
+| repo contract or governed-doc changes only | `scripts/docpact validate-config --root . --strict` and `scripts/docpact lint --root . --staged --mode enforce` | run one focused route check such as `scripts/docpact route --root . --intent repo-docs --format text` or `upstream-refresh` when the change touches release / automation docs | Refresh review evidence even when prose-only governed docs change. |
 
 ## Upstream Resolution Notes
 
@@ -91,4 +92,4 @@ Install the versioned local hook once per checkout:
 ./scripts/install-git-hooks.sh
 ```
 
-The `pre-push` hook runs `scripts/docpact-gate.sh`, which performs strict config validation and `docpact lint --mode enforce` before the push leaves the machine. The default comparison base is `origin/main`. Override it for unusual stacks with `DOCPACT_BASE_REF=<ref>` or `scripts/docpact-gate.sh --base <ref>`. The gate writes its detailed report to a temporary file so normal pushes do not create `.docpact/runs/` artifacts.
+The `pre-push` hook runs `scripts/docpact-gate.sh`, which delegates CLI lookup to `scripts/docpact` and performs strict config validation plus enforced lint before the push leaves the machine. The wrapper checks `DOCPACT_BIN`, Cargo install locations, Homebrew install locations, and then `PATH`, so local agent shells should not fail only because bare `docpact` is unavailable. The default comparison base is `origin/main`. Override it for unusual stacks with `DOCPACT_BASE_REF=<ref>` or `scripts/docpact-gate.sh --base <ref>`. The gate writes its detailed report to a temporary file so normal pushes do not create `.docpact/runs/` artifacts.

--- a/scripts/docpact
+++ b/scripts/docpact
@@ -1,0 +1,65 @@
+#!/bin/sh
+set -eu
+
+docpact_version="${DOCPACT_VERSION:-0.1.9}"
+
+use_candidate() {
+  candidate="$1"
+  if [ -n "$candidate" ] && [ -x "$candidate" ] && "$candidate" --version >/dev/null 2>&1; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+  return 1
+}
+
+find_docpact() {
+  if [ -n "${DOCPACT_BIN:-}" ]; then
+    if use_candidate "$DOCPACT_BIN"; then
+      return 0
+    fi
+    echo "DOCPACT_BIN is set but is not an executable docpact binary: $DOCPACT_BIN" >&2
+    return 127
+  fi
+
+  if [ -n "${CARGO_HOME:-}" ] && use_candidate "$CARGO_HOME/bin/docpact"; then
+    return 0
+  fi
+
+  if [ -n "${HOME:-}" ] && use_candidate "$HOME/.cargo/bin/docpact"; then
+    return 0
+  fi
+
+  if use_candidate "/opt/homebrew/bin/docpact"; then
+    return 0
+  fi
+
+  if use_candidate "/usr/local/bin/docpact"; then
+    return 0
+  fi
+
+  if command -v docpact >/dev/null 2>&1; then
+    candidate="$(command -v docpact)"
+    case "$candidate" in
+      */scripts/docpact | scripts/docpact | ./scripts/docpact)
+        ;;
+      *)
+        if use_candidate "$candidate"; then
+          return 0
+        fi
+        ;;
+    esac
+  fi
+
+  echo "docpact was not found." >&2
+  echo "Install it with: cargo install docpact --version $docpact_version --force" >&2
+  echo "Or set DOCPACT_BIN to an executable docpact binary." >&2
+  return 127
+}
+
+if [ "${1:-}" = "--print-bin" ]; then
+  find_docpact
+  exit 0
+fi
+
+docpact_bin="$(find_docpact)"
+exec "$docpact_bin" "$@"

--- a/scripts/docpact-gate.sh
+++ b/scripts/docpact-gate.sh
@@ -4,28 +4,7 @@ set -eu
 repo_root="$(git rev-parse --show-toplevel)"
 cd "$repo_root"
 
-find_docpact() {
-  if [ -n "${DOCPACT_BIN:-}" ] && "$DOCPACT_BIN" --version >/dev/null 2>&1; then
-    printf '%s\n' "$DOCPACT_BIN"
-    return 0
-  fi
-
-  if [ -x "$HOME/.cargo/bin/docpact" ] && "$HOME/.cargo/bin/docpact" --version >/dev/null 2>&1; then
-    printf '%s\n' "$HOME/.cargo/bin/docpact"
-    return 0
-  fi
-
-  if command -v docpact >/dev/null 2>&1; then
-    command -v docpact
-    return 0
-  fi
-
-  echo "docpact was not found. Install it with: cargo install docpact --version 0.1.4 --force" >&2
-  echo "Or set DOCPACT_BIN to an executable docpact binary." >&2
-  return 127
-}
-
-docpact_bin="$(find_docpact)"
+docpact_cmd="$repo_root/scripts/docpact"
 current_branch="$(git symbolic-ref --quiet --short HEAD 2>/dev/null || true)"
 head_ref="${DOCPACT_HEAD_REF:-HEAD}"
 base_ref="${DOCPACT_BASE_REF:-origin/main}"
@@ -65,7 +44,7 @@ report_path="${TMPDIR:-/tmp}/docpact-gate-$$.json"
 trap 'rm -f "$report_path"' EXIT HUP INT TERM
 
 echo "Running docpact config validation."
-"$docpact_bin" validate-config --root . --strict
+"$docpact_cmd" validate-config --root "$repo_root" --strict
 
 echo "Running docpact lint: base=$base_sha head=$head_sha."
-"$docpact_bin" lint --root . --base "$base_sha" --head "$head_sha" --mode enforce --output "$report_path"
+"$docpact_cmd" lint --root "$repo_root" --base "$base_sha" --head "$head_sha" --mode enforce --output "$report_path"

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -5,6 +5,6 @@ repo_root="$(git rev-parse --show-toplevel)"
 cd "$repo_root"
 
 git config core.hooksPath .githooks
-chmod +x .githooks/pre-push scripts/docpact-gate.sh
+chmod +x .githooks/pre-push scripts/docpact scripts/docpact-gate.sh
 
 echo "Configured git hooks: core.hooksPath=.githooks"


### PR DESCRIPTION
## Summary
- add a repo-local `scripts/docpact` wrapper for local CLI discovery
- route local docpact gates and CI doc-governance checks through the wrapper
- update docpact install guidance to the confirmed stable 0.1.9 release
- refresh repo-local governance docs so submodule working directories no longer depend on bare `docpact` being on `PATH`

## Validation
- `scripts/docpact validate-config --root <repo> --strict`
- `scripts/docpact lint --root <repo> --worktree --mode enforce`
- local docpact gate against the target base branch

No tracked issue was provided; this PR records the user-requested batch governance standardization.
