### PR TITLE
feat: speed up Python JSON Schema validation

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-19"
-lastReviewedCommit: "6ad233c9078362415d8781140171b89b67c4878d"
+lastReviewedAt: "2026-05-22"
+lastReviewedCommit: "893aa12cab10d0a6791e8c8aa42bb2624d665ee8"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,8 +30,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-19
-lastReviewedCommit: 6ad233c9078362415d8781140171b89b67c4878d
+lastReviewedAt: 2026-05-22
+lastReviewedCommit: 893aa12cab10d0a6791e8c8aa42bb2624d665ee8
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/README.md
+++ b/README.md
@@ -1,3 +1,28 @@
+---
+title: TIDAS SDKs
+docType: guide
+scope: repo
+status: active
+authoritative: false
+owner: tidas-sdk
+language: en
+whenToUse:
+  - when getting oriented to the tidas-sdk repository
+  - when looking for package locations, setup commands, or verification entrypoints
+whenToUpdate:
+  - when package status, setup commands, generation flow, or verification entrypoints change
+checkPaths:
+  - README.md
+  - AGENTS.md
+  - docs/agents/repo-validation.md
+  - docs/agents/repo-architecture.md
+  - sdks/typescript/**
+  - sdks/python/**
+  - scripts/ci/**
+lastReviewedAt: 2026-05-22
+lastReviewedCommit: 893aa12cab10d0a6791e8c8aa42bb2624d665ee8
+---
+
 # TIDAS SDKs
 
 A multi-language SDK repository for TIDAS (TianGong Life Cycle Assessment data format), providing the generated TypeScript package, the in-repo Python SDK, and the automation that refreshes and releases them from `tidas-tools`.

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -25,8 +25,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-19
-lastReviewedCommit: 6ad233c9078362415d8781140171b89b67c4878d
+lastReviewedAt: 2026-05-22
+lastReviewedCommit: 893aa12cab10d0a6791e8c8aa42bb2624d665ee8
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -27,8 +27,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-19
-lastReviewedCommit: 6ad233c9078362415d8781140171b89b67c4878d
+lastReviewedAt: 2026-05-22
+lastReviewedCommit: 893aa12cab10d0a6791e8c8aa42bb2624d665ee8
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -16,8 +16,8 @@ checkPaths:
   - .github/workflows/publish.yml
   - .github/workflows/tag-release-from-merge.yml
   - .docpact/config.yaml
-lastReviewedAt: 2026-05-19
-lastReviewedCommit: 6ad233c9078362415d8781140171b89b67c4878d
+lastReviewedAt: 2026-05-22
+lastReviewedCommit: 893aa12cab10d0a6791e8c8aa42bb2624d665ee8
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/upstream-automation.md
+++ b/docs/upstream-automation.md
@@ -17,8 +17,8 @@ checkPaths:
   - .github/workflows/sync-from-tidas-tools.yml
   - .github/workflows/tag-release-from-merge.yml
   - .docpact/config.yaml
-lastReviewedAt: 2026-05-19
-lastReviewedCommit: 6ad233c9078362415d8781140171b89b67c4878d
+lastReviewedAt: 2026-05-22
+lastReviewedCommit: 893aa12cab10d0a6791e8c8aa42bb2624d665ee8
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/scripts/ci/generate-python-sdk.sh
+++ b/scripts/ci/generate-python-sdk.sh
@@ -73,7 +73,7 @@ validate_inputs() {
 check_dependencies() {
     step "Checking dependencies..."
     if command -v uv >/dev/null 2>&1; then
-        PYTHON_RUNNER=(uv run python)
+        PYTHON_RUNNER=(uv --directory "$PYTHON_SDK_ROOT" run python)
     elif command -v python3 >/dev/null 2>&1; then
         PYTHON_RUNNER=(python3)
     else

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tidas-sdk"
-version = "0.2.9"
+version = "0.2.10"
 description = "Python SDK for TIDAS/ILCD Life Cycle Assessment data"
 authors = [{ name = "Tiangong LCA Team" }]
 license = { text = "MIT" }
@@ -11,6 +11,7 @@ dependencies = [
     "loguru>=0.7.0",
     "typing-extensions>=4.0.0; python_version<'3.10'",
     "jsonschema>=4.19.0",
+    "fastjsonschema>=2.21.2",
 ]
 keywords = ["tidas", "ilcd", "lca", "life-cycle-assessment"]
 

--- a/sdks/python/src/tidas_sdk/core/base.py
+++ b/sdks/python/src/tidas_sdk/core/base.py
@@ -1,22 +1,41 @@
 """
 Core abstractions shared by all generated entities.
 """
+
 from __future__ import annotations
 
 from collections.abc import Mapping, MutableSequence
 from copy import deepcopy
+from dataclasses import dataclass
+from functools import lru_cache
 import json
 from pathlib import Path
-from typing import Any, ClassVar, Generic, Literal, Sequence, TypeVar, cast, get_args, get_origin
+from typing import (
+    Any,
+    ClassVar,
+    Generic,
+    Literal,
+    Protocol,
+    Sequence,
+    TypeVar,
+    cast,
+    get_args,
+    get_origin,
+)
 
+import fastjsonschema  # type: ignore[import-untyped]
 from jsonschema import FormatChecker, ValidationError as JsonSchemaValidationError, validators  # type: ignore[import-untyped]
-from pydantic import BaseModel, ConfigDict, ValidationError as PydanticValidationError, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    ValidationError as PydanticValidationError,
+    model_validator,
+)
 from referencing import Registry, Resource
 
 from .cas_number import is_valid_cas_number
 from .multilang import MultiLangList, deep_wrap_multilang, validate_multilang_entries
 from tidas_sdk.schemas import load_schema, load_schema_store, schema_exists
-
 
 _FORMAT_CHECKER = FormatChecker()
 
@@ -54,6 +73,98 @@ class TidasBaseModel(BaseModel):
 ModelT = TypeVar("ModelT", bound=TidasBaseModel)
 
 ValidationMode = Literal["pydantic", "jsonschema", "both"]
+
+
+class FastJsonSchemaValidator(Protocol):
+    def __call__(self, data: Any) -> Any:
+        """
+        Validate data and return the validated payload when it passes.
+        """
+
+
+@dataclass(frozen=True)
+class JsonSchemaValidators:
+    strict_validator: Any
+    fast_validator: FastJsonSchemaValidator | None
+
+
+def _fast_jsonschema_schema_handler(uri: str) -> dict[str, Any]:
+    schema_name = Path(uri.split("#", 1)[0]).name
+    if not schema_name:
+        raise fastjsonschema.JsonSchemaDefinitionException(
+            f"Unsupported empty schema reference: {uri}"
+        )
+    schema = load_schema(schema_name)
+    return _normalize_fast_jsonschema_schema({**schema, "$id": schema_name})
+
+
+def _normalize_fast_jsonschema_schema(node: Any) -> Any:
+    if isinstance(node, dict):
+        normalized = {
+            key: _normalize_fast_jsonschema_schema(value) for key, value in node.items()
+        }
+        if normalized.get("then") == {}:
+            normalized.pop("then")
+        if normalized.get("else") == {}:
+            normalized.pop("else")
+        return normalized
+    if isinstance(node, list):
+        return [_normalize_fast_jsonschema_schema(value) for value in node]
+    return node
+
+
+@lru_cache(maxsize=1)
+def _fast_jsonschema_handlers() -> dict[str, Any]:
+    handlers: dict[str, Any] = {"": _fast_jsonschema_schema_handler}
+    for schema_name in load_schema_store():
+        if not schema_name.endswith(".json"):
+            continue
+        normalized_name = Path(schema_name).name
+        handlers[normalized_name] = _fast_jsonschema_schema_handler
+        handlers[f"./{normalized_name}"] = _fast_jsonschema_schema_handler
+    return handlers
+
+
+def _compile_fast_jsonschema_definition(
+    schema_name: str, schema_definition: dict[str, Any]
+) -> FastJsonSchemaValidator:
+    schema = _normalize_fast_jsonschema_schema(
+        {**schema_definition, "$id": schema_name}
+    )
+    return cast(
+        FastJsonSchemaValidator,
+        fastjsonschema.compile(
+            schema,
+            handlers=_fast_jsonschema_handlers(),
+            formats={"cas-number": _is_jsonschema_cas_number},
+            use_default=False,
+        ),
+    )
+
+
+@lru_cache(maxsize=1)
+def _build_cached_schema_registry() -> Registry:
+    registry = Registry()
+    for uri, schema in load_schema_store().items():
+        registry = registry.with_resource(uri, Resource.from_contents(schema))
+    return registry
+
+
+@lru_cache(maxsize=None)
+def _get_jsonschema_validator(schema_name: str) -> JsonSchemaValidators:
+    schema = load_schema(schema_name)
+    validator_cls = validators.validator_for(schema)
+    validator_cls.check_schema(schema)
+    strict_validator = validator_cls(
+        schema,
+        registry=_build_cached_schema_registry(),
+        format_checker=_FORMAT_CHECKER,
+    )
+    try:
+        fast_validator = _compile_fast_jsonschema_definition(schema_name, schema)
+    except Exception:
+        fast_validator = None
+    return JsonSchemaValidators(strict_validator, fast_validator)
 
 
 class TidasEntity(Generic[ModelT]):
@@ -169,7 +280,9 @@ class TidasEntity(Generic[ModelT]):
         """
         Access the cached validation error from the previous run (if any).
         """
-        return cast(PydanticValidationError | None, getattr(self, "_last_pydantic_error", None))
+        return cast(
+            PydanticValidationError | None, getattr(self, "_last_pydantic_error", None)
+        )
 
     def jsonschema_errors(self) -> list[str] | None:
         """
@@ -206,15 +319,21 @@ class TidasEntity(Generic[ModelT]):
             return False
 
         try:
-            schema = load_schema(schema_name)
-            validator_cls = validators.validator_for(schema)
-            validator_cls.check_schema(schema)
-            validator = validator_cls(
-                schema,
-                registry=self._build_schema_registry(),
-                format_checker=_FORMAT_CHECKER,
+            validator = _get_jsonschema_validator(schema_name)
+            if validator.fast_validator is not None:
+                try:
+                    validator.fast_validator(data)
+                    object.__setattr__(self, "_last_jsonschema_errors", [])
+                    return True
+                except fastjsonschema.JsonSchemaValueException:
+                    pass
+                except fastjsonschema.JsonSchemaException:
+                    pass
+
+            errors = sorted(
+                validator.strict_validator.iter_errors(data),
+                key=lambda err: list(err.path),
             )
-            errors = sorted(validator.iter_errors(data), key=lambda err: list(err.path))
         except Exception as exc:
             object.__setattr__(
                 self,
@@ -246,10 +365,7 @@ class TidasEntity(Generic[ModelT]):
 
     @staticmethod
     def _build_schema_registry() -> Registry:
-        registry = Registry()
-        for uri, schema in load_schema_store().items():
-            registry = registry.with_resource(uri, Resource.from_contents(schema))
-        return registry
+        return _build_cached_schema_registry()
 
     # -- loading helpers ------------------------------------------------------------------
 
@@ -353,11 +469,15 @@ class TidasEntity(Generic[ModelT]):
             if nested_cls is None:
                 return value
             return [
-                nested_cls.model_construct(
-                    **self._prepare_partial_payload(nested_cls, cast(Mapping[str, Any], item))
+                (
+                    nested_cls.model_construct(
+                        **self._prepare_partial_payload(
+                            nested_cls, cast(Mapping[str, Any], item)
+                        )
+                    )
+                    if isinstance(item, Mapping)
+                    else item
                 )
-                if isinstance(item, Mapping)
-                else item
                 for item in value
             ]
         return value
@@ -406,7 +526,9 @@ class TidasEntity(Generic[ModelT]):
             return value
         if isinstance(value, TidasBaseModel):
             return self._collect_runtime_payload(value)
-        if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        if isinstance(value, Sequence) and not isinstance(
+            value, (str, bytes, bytearray)
+        ):
             items: list[Any] = []
             for item in value:
                 if isinstance(item, MultiLangList):

--- a/sdks/python/tests/test_flow_validation_parity.py
+++ b/sdks/python/tests/test_flow_validation_parity.py
@@ -4,20 +4,30 @@ import json
 from copy import deepcopy
 from pathlib import Path
 
-from tidas_sdk import create_flow
+import fastjsonschema
+import pytest
 
+from tidas_sdk import create_flow
+from tidas_sdk.core.base import (
+    _compile_fast_jsonschema_definition,
+    _get_jsonschema_validator,
+)
 
 FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
 
 
 def _load_payload() -> dict[str, object]:
-    return json.loads((FIXTURES_DIR / "flow-validation-parity.json").read_text(encoding="utf-8"))
+    return json.loads(
+        (FIXTURES_DIR / "flow-validation-parity.json").read_text(encoding="utf-8")
+    )
 
 
 def _payload_with_required_name_fields() -> dict[str, object]:
     payload = deepcopy(_load_payload())
     name = payload["flowDataSet"]["flowInformation"]["dataSetInformation"]["name"]
-    name["treatmentStandardsRoutes"] = [{"@xml:lang": "en", "#text": "tar, syngas, char"}]
+    name["treatmentStandardsRoutes"] = [
+        {"@xml:lang": "en", "#text": "tar, syngas, char"}
+    ]
     name["mixAndLocationTypes"] = [{"@xml:lang": "en", "#text": "at plant"}]
     return payload
 
@@ -38,7 +48,10 @@ def test_flow_pydantic_validation_rejects_missing_required_name_fields() -> None
     assert error is not None
 
     rendered = str(error)
-    assert "treatmentStandardsRoutes" in rendered or "treatment_standards_routes" in rendered
+    assert (
+        "treatmentStandardsRoutes" in rendered
+        or "treatment_standards_routes" in rendered
+    )
     assert "mixAndLocationTypes" in rendered or "mix_and_location_types" in rendered
 
 
@@ -52,14 +65,18 @@ def test_flow_pydantic_validation_rejects_invalid_localized_text() -> None:
     assert "must not contain Chinese characters" in str(error)
 
 
-def test_flow_jsonschema_validation_returns_validation_errors_not_execution_errors() -> None:
+def test_flow_jsonschema_validation_returns_validation_errors_not_execution_errors() -> (
+    None
+):
     entity = create_flow(_load_payload())
 
     assert entity.validate(mode="jsonschema") is False
 
     errors = entity.jsonschema_errors()
     assert errors
-    assert all("Schema validation failed to execute" not in message for message in errors)
+    assert all(
+        "Schema validation failed to execute" not in message for message in errors
+    )
     assert all("None is not of type 'string'" not in message for message in errors)
     assert all("datetime.datetime" not in message for message in errors)
     assert any("treatmentStandardsRoutes" in message for message in errors)
@@ -75,3 +92,44 @@ def test_flow_jsonschema_validation_rejects_invalid_cas_check_digit() -> None:
     errors = entity.jsonschema_errors()
     assert errors
     assert any("CASNumber" in message and "cas-number" in message for message in errors)
+
+
+def test_flow_jsonschema_validator_is_cached_with_fast_path() -> None:
+    validator = _get_jsonschema_validator("tidas_flows.json")
+
+    assert validator is _get_jsonschema_validator("tidas_flows.json")
+    assert validator.fast_validator is not None
+
+
+def test_fast_jsonschema_validation_supports_refs_and_cas_format() -> None:
+    validator = _compile_fast_jsonschema_definition(
+        "test_schema.json",
+        {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": {"cas": {"$ref": "tidas_data_types.json#/$defs/CASNumber"}},
+            "required": ["cas"],
+        },
+    )
+
+    assert validator({"cas": "64-17-5"}) == {"cas": "64-17-5"}
+
+    with pytest.raises(fastjsonschema.JsonSchemaValueException) as exc_info:
+        validator({"cas": "64-17-6"})
+
+    assert exc_info.value.rule == "format"
+
+
+def test_fast_jsonschema_validation_does_not_apply_defaults() -> None:
+    validator = _compile_fast_jsonschema_definition(
+        "test_defaults.json",
+        {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": {"name": {"type": "string", "default": "generated"}},
+        },
+    )
+    payload: dict[str, object] = {}
+
+    assert validator(payload) == {}
+    assert payload == {}


### PR DESCRIPTION
Closes tiangong-lca/tidas-sdk#70

## Summary
- Cache Python SDK JSON Schema validators and add a fastjsonschema success path.
- Fall back to the existing jsonschema error collector when fast validation fails so current error formatting is preserved.
- Bump the Python SDK package to 0.2.10 for tag-driven PyPI release.

## Key Decisions
- Keep bulk validation out of the SDK; this change only improves per-entity JSON Schema validation.
- Use fastjsonschema only as a fast path and retain jsonschema as the canonical failure formatter.

## Validation
- uv run pytest tests/test_flow_validation_parity.py
- uv run ruff check src/tidas_sdk/core/base.py tests/test_flow_validation_parity.py
- uv run black --check src/tidas_sdk/core/base.py tests/test_flow_validation_parity.py
- ./scripts/ci/verify-python-package.sh
- docpact lint --worktree
- git diff --check

## Risks / Rollback
- Low runtime risk: failures continue through the previous jsonschema error path.

## Follow-ups
- Tag-driven publish should create python-v0.2.10 after this PR merges to main.

## Workspace Integration
- Workspace integration remains pending until lca-workspace bumps the tidas-sdk submodule pointer after release.