### PR TITLE
[codex] Prepare TypeScript SDK 0.1.41 without LangChain

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-22"
-lastReviewedCommit: "893aa12cab10d0a6791e8c8aa42bb2624d665ee8"
+lastReviewedAt: "2026-05-25"
+lastReviewedCommit: "02724b146504f2cae725e736a0017136c0122412"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,8 +30,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-22
-lastReviewedCommit: 893aa12cab10d0a6791e8c8aa42bb2624d665ee8
+lastReviewedAt: 2026-05-25
+lastReviewedCommit: 02724b146504f2cae725e736a0017136c0122412
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -25,8 +25,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-22
-lastReviewedCommit: 893aa12cab10d0a6791e8c8aa42bb2624d665ee8
+lastReviewedAt: 2026-05-25
+lastReviewedCommit: 02724b146504f2cae725e736a0017136c0122412
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -27,8 +27,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-22
-lastReviewedCommit: 893aa12cab10d0a6791e8c8aa42bb2624d665ee8
+lastReviewedAt: 2026-05-25
+lastReviewedCommit: 02724b146504f2cae725e736a0017136c0122412
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -16,8 +16,8 @@ checkPaths:
   - .github/workflows/publish.yml
   - .github/workflows/tag-release-from-merge.yml
   - .docpact/config.yaml
-lastReviewedAt: 2026-05-22
-lastReviewedCommit: 893aa12cab10d0a6791e8c8aa42bb2624d665ee8
+lastReviewedAt: 2026-05-25
+lastReviewedCommit: 02724b146504f2cae725e736a0017136c0122412
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/upstream-automation.md
+++ b/docs/upstream-automation.md
@@ -17,8 +17,8 @@ checkPaths:
   - .github/workflows/sync-from-tidas-tools.yml
   - .github/workflows/tag-release-from-merge.yml
   - .docpact/config.yaml
-lastReviewedAt: 2026-05-22
-lastReviewedCommit: 893aa12cab10d0a6791e8c8aa42bb2624d665ee8
+lastReviewedAt: 2026-05-25
+lastReviewedCommit: 02724b146504f2cae725e736a0017136c0122412
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/sdks/typescript/README-zh.md
+++ b/sdks/typescript/README-zh.md
@@ -288,6 +288,9 @@ import { createProcess, suggestData } from '@tiangong-lca/tidas-sdk';
 
 // 设置 OpenAI API 密钥（必需）
 process.env.OPENAI_API_KEY = 'your-api-key';
+// 可选：使用 OpenAI-compatible 服务
+process.env.OPENAI_BASE_URL = 'https://api.openai.com/v1';
+process.env.OPENAI_CHAT_MODEL = 'gpt-4.1-mini';
 
 // 方法 1：使用实体的 suggest 方法
 const process = createProcess({ processDataSet: { /* 不完整的数据 */ } });
@@ -307,7 +310,11 @@ const improvedResult = await suggestData(
   {
     skipPaths: ['administrativeInformation'],  // 跳过某些路径
     maxRetries: 2,                              // 验证失败时重试
-    outputDiffSummary: true
+    outputDiffSummary: true,
+    modelConfig: {
+      baseURL: process.env.OPENAI_BASE_URL,     // 兼容 OpenAI-style /v1 API
+      model: process.env.OPENAI_CHAT_MODEL,
+    },
   }
 );
 

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,17 +1,15 @@
 {
   "name": "@tiangong-lca/tidas-sdk",
-  "version": "0.1.40",
+  "version": "0.1.41",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tiangong-lca/tidas-sdk",
-      "version": "0.1.40",
+      "version": "0.1.41",
       "license": "MIT",
       "dependencies": {
-        "@langchain/core": "^0.3.72",
         "jsonschema": "^1.5.0",
-        "langchain": "^0.3.31",
         "ts-to-zod": "^3.15.0",
         "xmltodict": "^1.0.5",
         "yaml": "^2.8.1",
@@ -83,7 +81,6 @@
       "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -567,12 +564,6 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@cfworker/json-schema": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
-      "integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
       "license": "MIT"
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -1856,171 +1847,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@langchain/core": {
-      "version": "0.3.72",
-      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.72.tgz",
-      "integrity": "sha512-WsGWVZYnlKffj2eEfDocPNiaTRoxyYiLSQdQ7oxZvxGZBqo/90vpjbC33UGK1uPNBM4kT+pkdaol/MnvKUh8TQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@cfworker/json-schema": "^4.0.2",
-        "ansi-styles": "^5.0.0",
-        "camelcase": "6",
-        "decamelize": "1.2.0",
-        "js-tiktoken": "^1.0.12",
-        "langsmith": "^0.3.46",
-        "mustache": "^4.2.0",
-        "p-queue": "^6.6.2",
-        "p-retry": "4",
-        "uuid": "^10.0.0",
-        "zod": "^3.25.32",
-        "zod-to-json-schema": "^3.22.3"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@langchain/core/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@langchain/core/node_modules/camelcase": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@langchain/core/node_modules/langsmith": {
-      "version": "0.3.64",
-      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.3.64.tgz",
-      "integrity": "sha512-67yccwrREK5pgVX7PktkUImbNT4bQpSPH7SETSPYZ+X42OpGGAABU4s+pNV/55/ke+INrmpXXlKxfMpZOCrzQA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/uuid": "^10.0.0",
-        "chalk": "^4.1.2",
-        "console-table-printer": "^2.12.1",
-        "p-queue": "^6.6.2",
-        "p-retry": "4",
-        "semver": "^7.6.3",
-        "uuid": "^10.0.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "*",
-        "@opentelemetry/exporter-trace-otlp-proto": "*",
-        "@opentelemetry/sdk-trace-base": "*",
-        "openai": "*"
-      },
-      "peerDependenciesMeta": {
-        "@opentelemetry/api": {
-          "optional": true
-        },
-        "@opentelemetry/exporter-trace-otlp-proto": {
-          "optional": true
-        },
-        "@opentelemetry/sdk-trace-base": {
-          "optional": true
-        },
-        "openai": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@langchain/core/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@langchain/core/node_modules/zod-to-json-schema": {
-      "version": "3.24.6",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
-      "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.24.1"
-      }
-    },
-    "node_modules/@langchain/openai": {
-      "version": "0.6.9",
-      "resolved": "https://registry.npmjs.org/@langchain/openai/-/openai-0.6.9.tgz",
-      "integrity": "sha512-Dl+YVBTFia7WE4/jFemQEVchPbsahy/dD97jo6A9gLnYfTkWa/jh8Q78UjHQ3lobif84j2ebjHPcDHG1L0NUWg==",
-      "license": "MIT",
-      "dependencies": {
-        "js-tiktoken": "^1.0.12",
-        "openai": "5.12.2",
-        "zod": "^3.25.32"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@langchain/core": ">=0.3.68 <0.4.0"
-      }
-    },
-    "node_modules/@langchain/openai/node_modules/openai": {
-      "version": "5.12.2",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-5.12.2.tgz",
-      "integrity": "sha512-xqzHHQch5Tws5PcKR2xsZGX9xtch+JQFz5zb14dGqlshmmDAFBFEWmeIpf7wVqWV+w7Emj7jRgkNJakyKE0tYQ==",
-      "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
-      },
-      "peerDependencies": {
-        "ws": "^8.18.0",
-        "zod": "^3.23.8"
-      },
-      "peerDependenciesMeta": {
-        "ws": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@langchain/openai/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@langchain/textsplitters": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@langchain/textsplitters/-/textsplitters-0.1.0.tgz",
-      "integrity": "sha512-djI4uw9rlkAb5iMhtLED+xJebDdAG935AdP4eRTB02R7OB/act55Bj9wsskhZsvuyQRpO4O1wQOp85s6T6GWmw==",
-      "license": "MIT",
-      "dependencies": {
-        "js-tiktoken": "^1.0.12"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@langchain/core": ">=0.2.21 <0.4.0"
-      }
-    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.11.tgz",
@@ -2367,28 +2193,15 @@
       "integrity": "sha512-4zXMWD91vBLGRtHK3YbIoFMia+1nqEz72coM42C5ETjnNCa/heoj7NT1G67iAfOqMmcfhuCZ4uNpyz8EjlAejw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.8.0"
       }
-    },
-    "node_modules/@types/retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
-      "license": "MIT"
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
@@ -2444,7 +2257,6 @@
       "integrity": "sha512-FuYgkHwZLuPbZjQHzJXrtXreJdFMKl16BFYyRrLxDhWr6Qr7Kbcu2s1Yhu8tsiMXw1S0W1pjfFfYEt+R604s+Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.36.0",
         "@typescript-eslint/types": "8.36.0",
@@ -2937,7 +2749,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3061,6 +2872,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/async": {
@@ -3257,7 +3069,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -3642,15 +3453,6 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "license": "MIT"
     },
-    "node_modules/console-table-printer": {
-      "version": "2.14.6",
-      "resolved": "https://registry.npmjs.org/console-table-printer/-/console-table-printer-2.14.6.tgz",
-      "integrity": "sha512-MCBl5HNVaFuuHW6FGbL/4fB7N/ormCy+tQ+sxTrF6QtSbSNETvPuOVbkJBhzDgYhvjWGrTma4eYJa37ZuoQsPw==",
-      "license": "MIT",
-      "dependencies": {
-        "simple-wcswidth": "^1.0.1"
-      }
-    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -3695,15 +3497,6 @@
         "supports-color": {
           "optional": true
         }
-      }
-    },
-    "node_modules/decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/dedent": {
@@ -3912,7 +3705,6 @@
       "integrity": "sha512-zmxXPNMOXmwm9E0yQLi5uqXHs7uq2UIiqEKo3Gq+3fwo1XrJ+hijAZImyF7hclW3E6oHz43Yk3RP8at6OTKflQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4161,12 +3953,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/eventemitter3": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "license": "MIT"
     },
     "node_modules/execa": {
       "version": "5.1.1",
@@ -5091,7 +4877,6 @@
       "integrity": "sha512-9QE0RS4WwTj/TtTC4h/eFVmFAhGNVerSB9XpJh8sqaXlP73ILcPcZ7JWjjEtJJe2m8QyBLKKfPQuK+3F+Xij/g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.0.4",
         "@jest/types": "30.0.1",
@@ -5679,15 +5464,6 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "node_modules/js-tiktoken": {
-      "version": "1.0.21",
-      "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.21.tgz",
-      "integrity": "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==",
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.5.1"
-      }
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5699,6 +5475,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -5773,15 +5550,6 @@
         "graceful-fs": "^4.1.6"
       }
     },
-    "node_modules/jsonpointer": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
-      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/jsonschema": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.5.0.tgz",
@@ -5799,145 +5567,6 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
-      }
-    },
-    "node_modules/langchain": {
-      "version": "0.3.31",
-      "resolved": "https://registry.npmjs.org/langchain/-/langchain-0.3.31.tgz",
-      "integrity": "sha512-C7n7WGa44RytsuxEtGcArVcXidRqzjl6UWQxaG3NdIw4gIqErWoOlNC1qADAa04H5JAOARxuE6S99+WNXB/rzA==",
-      "license": "MIT",
-      "dependencies": {
-        "@langchain/openai": ">=0.1.0 <0.7.0",
-        "@langchain/textsplitters": ">=0.0.0 <0.2.0",
-        "js-tiktoken": "^1.0.12",
-        "js-yaml": "^4.1.0",
-        "jsonpointer": "^5.0.1",
-        "langsmith": "^0.3.46",
-        "openapi-types": "^12.1.3",
-        "p-retry": "4",
-        "uuid": "^10.0.0",
-        "yaml": "^2.2.1",
-        "zod": "^3.25.32"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@langchain/anthropic": "*",
-        "@langchain/aws": "*",
-        "@langchain/cerebras": "*",
-        "@langchain/cohere": "*",
-        "@langchain/core": ">=0.3.58 <0.4.0",
-        "@langchain/deepseek": "*",
-        "@langchain/google-genai": "*",
-        "@langchain/google-vertexai": "*",
-        "@langchain/google-vertexai-web": "*",
-        "@langchain/groq": "*",
-        "@langchain/mistralai": "*",
-        "@langchain/ollama": "*",
-        "@langchain/xai": "*",
-        "axios": "*",
-        "cheerio": "*",
-        "handlebars": "^4.7.8",
-        "peggy": "^3.0.2",
-        "typeorm": "*"
-      },
-      "peerDependenciesMeta": {
-        "@langchain/anthropic": {
-          "optional": true
-        },
-        "@langchain/aws": {
-          "optional": true
-        },
-        "@langchain/cerebras": {
-          "optional": true
-        },
-        "@langchain/cohere": {
-          "optional": true
-        },
-        "@langchain/deepseek": {
-          "optional": true
-        },
-        "@langchain/google-genai": {
-          "optional": true
-        },
-        "@langchain/google-vertexai": {
-          "optional": true
-        },
-        "@langchain/google-vertexai-web": {
-          "optional": true
-        },
-        "@langchain/groq": {
-          "optional": true
-        },
-        "@langchain/mistralai": {
-          "optional": true
-        },
-        "@langchain/ollama": {
-          "optional": true
-        },
-        "@langchain/xai": {
-          "optional": true
-        },
-        "axios": {
-          "optional": true
-        },
-        "cheerio": {
-          "optional": true
-        },
-        "handlebars": {
-          "optional": true
-        },
-        "peggy": {
-          "optional": true
-        },
-        "typeorm": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/langchain/node_modules/langsmith": {
-      "version": "0.3.64",
-      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.3.64.tgz",
-      "integrity": "sha512-67yccwrREK5pgVX7PktkUImbNT4bQpSPH7SETSPYZ+X42OpGGAABU4s+pNV/55/ke+INrmpXXlKxfMpZOCrzQA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/uuid": "^10.0.0",
-        "chalk": "^4.1.2",
-        "console-table-printer": "^2.12.1",
-        "p-queue": "^6.6.2",
-        "p-retry": "4",
-        "semver": "^7.6.3",
-        "uuid": "^10.0.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "*",
-        "@opentelemetry/exporter-trace-otlp-proto": "*",
-        "@opentelemetry/sdk-trace-base": "*",
-        "openai": "*"
-      },
-      "peerDependenciesMeta": {
-        "@opentelemetry/api": {
-          "optional": true
-        },
-        "@opentelemetry/exporter-trace-otlp-proto": {
-          "optional": true
-        },
-        "@opentelemetry/sdk-trace-base": {
-          "optional": true
-        },
-        "openai": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/langchain/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/leven": {
@@ -6149,15 +5778,6 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
-    "node_modules/mustache": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
-      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
-      "license": "MIT",
-      "bin": {
-        "mustache": "bin/mustache"
-      }
-    },
     "node_modules/mute-stream": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
@@ -6254,12 +5874,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/openapi-types": {
-      "version": "12.1.3",
-      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
-      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
-      "license": "MIT"
-    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -6331,15 +5945,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/p-finally": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -6370,47 +5975,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-queue": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
-      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
-      "license": "MIT",
-      "dependencies": {
-        "eventemitter3": "^4.0.4",
-        "p-timeout": "^3.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-retry": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
-      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/retry": "0.12.0",
-        "retry": "^0.13.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/p-timeout": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
-      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
-      "license": "MIT",
-      "dependencies": {
-        "p-finally": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/p-try": {
@@ -6821,15 +6385,6 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
     },
-    "node_modules/retry": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -6968,12 +6523,6 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
-    },
-    "node_modules/simple-wcswidth": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/simple-wcswidth/-/simple-wcswidth-1.1.2.tgz",
-      "integrity": "sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==",
-      "license": "MIT"
     },
     "node_modules/slash": {
       "version": "3.0.0",
@@ -7376,7 +6925,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7500,7 +7048,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -7677,7 +7224,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7806,19 +7352,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tiangong-lca/tidas-sdk",
-  "version": "0.1.40",
+  "version": "0.1.41",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "module": "./dist/index.js",
@@ -114,9 +114,7 @@
     "node": ">=24.0.0"
   },
   "dependencies": {
-    "@langchain/core": "^0.3.72",
     "jsonschema": "^1.5.0",
-    "langchain": "^0.3.31",
     "ts-to-zod": "^3.15.0",
     "xmltodict": "^1.0.5",
     "yaml": "^2.8.1",

--- a/sdks/typescript/src/core/base/TidasEntity.ts
+++ b/sdks/typescript/src/core/base/TidasEntity.ts
@@ -488,6 +488,7 @@ export abstract class TidasEntity<T = any> {
         {
           skipPaths: options?.skipPaths,
           maxRetries: options?.maxRetries,
+          modelConfig: options?.modelConfig,
         }
       );
 

--- a/sdks/typescript/src/core/copilot/ai.test.ts
+++ b/sdks/typescript/src/core/copilot/ai.test.ts
@@ -1,0 +1,69 @@
+import type { Schema } from '../../utils/object-utils';
+import { extractJson, getModel } from './ai';
+
+describe('OpenAI-compatible copilot helpers', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  it('extracts fenced and direct JSON without an external parser', () => {
+    const schema: Schema = {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+      },
+    };
+
+    expect(extractJson('{"name":"steel"}', schema)).toEqual({
+      name: 'steel',
+    });
+    expect(extractJson('```json\n{"name":"steel"}\n```', schema)).toEqual({
+      name: 'steel',
+    });
+  });
+
+  it('posts to an OpenAI-compatible chat completions endpoint', async () => {
+    const calls: Array<{ url: string; init: RequestInit }> = [];
+    global.fetch = jest.fn(async (url, init) => {
+      calls.push({ url: String(url), init: init as RequestInit });
+      return new Response(
+        JSON.stringify({
+          choices: [
+            {
+              message: {
+                content: '{"ok":true}',
+              },
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      );
+    }) as unknown as typeof fetch;
+
+    const model = await getModel({
+      apiKey: 'test-key',
+      baseURL: 'https://example.test/v1',
+      model: 'test-model',
+    });
+    const result = await model.invoke('hello');
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe('https://example.test/v1/chat/completions');
+    expect(calls[0].init.headers).toEqual({
+      Authorization: 'Bearer test-key',
+      'Content-Type': 'application/json',
+    });
+    expect(JSON.parse(calls[0].init.body as string)).toEqual({
+      model: 'test-model',
+      messages: [{ role: 'user', content: 'hello' }],
+      temperature: 0,
+    });
+    expect(result.content).toBe('{"ok":true}');
+  });
+});

--- a/sdks/typescript/src/core/copilot/ai.ts
+++ b/sdks/typescript/src/core/copilot/ai.ts
@@ -1,6 +1,3 @@
-import { ChatOpenAI } from '@langchain/openai';
-import { PromptTemplate } from '@langchain/core/prompts';
-import { JsonOutputParser } from '@langchain/core/output_parsers';
 import {
   generateSchema,
   validateSchema,
@@ -14,63 +11,299 @@ import {
   availableMethodologies,
 } from './base';
 
+type ChatRole = 'system' | 'user' | 'assistant';
+
+type ChatMessage = {
+  role: ChatRole;
+  content: string;
+};
+
+type ChatCompletionOptions = {
+  temperature?: number;
+};
+
+type OpenAIChatResult = {
+  text: string;
+  raw: unknown;
+};
+
+const DEFAULT_OPENAI_BASE_URL = 'https://api.openai.com/v1';
+const DEFAULT_OPENAI_CHAT_MODEL = 'gpt-4.1-mini';
+const DEFAULT_REQUEST_TIMEOUT_MS = 120_000;
+
 /**
  * Model configuration object
  * @param model - The model to use
  * @param apiKey - The API key to use
- * @param baseURL - The base URL to use
+ * @param baseURL - The OpenAI-compatible base URL to use
+ * @param baseUrl - Alias for baseURL
+ * @param temperature - Sampling temperature for chat completions
+ * @param timeoutMs - Request timeout in milliseconds
  */
 export type ModelConfig = {
   model?: string;
   apiKey?: string;
   baseURL?: string;
+  baseUrl?: string;
+  temperature?: number;
+  timeoutMs?: number;
 };
 
-async function getModel(modelConfig: ModelConfig) {
-  const chat_model = new ChatOpenAI({
-    model: modelConfig.model || process.env.OPENAI_CHAT_MODEL,
-    configuration: {
-      apiKey: modelConfig.apiKey || process.env.OPENAI_API_KEY,
-      baseURL: modelConfig.baseURL || process.env.OPENAI_BASE_URL,
-    },
-  });
-  return chat_model;
+function getConfiguredApiKey(modelConfig: ModelConfig): string {
+  const apiKey = modelConfig.apiKey || process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new Error('Missing OPENAI_API_KEY environment variable');
+  }
+  return apiKey;
+}
+
+function getConfiguredBaseUrl(modelConfig: ModelConfig): string {
+  return (
+    modelConfig.baseURL ||
+    modelConfig.baseUrl ||
+    process.env.OPENAI_BASE_URL ||
+    DEFAULT_OPENAI_BASE_URL
+  );
+}
+
+function getConfiguredModel(modelConfig: ModelConfig): string {
+  return (
+    modelConfig.model ||
+    process.env.OPENAI_CHAT_MODEL ||
+    DEFAULT_OPENAI_CHAT_MODEL
+  );
+}
+
+function resolveChatCompletionsUrl(baseUrl: string): string {
+  const trimmed = baseUrl.replace(/\/+$/, '');
+  if (/\/chat\/completions$/i.test(trimmed)) {
+    return trimmed;
+  }
+  return `${trimmed}/chat/completions`;
+}
+
+function readTextContent(content: unknown): string {
+  if (typeof content === 'string') {
+    return content;
+  }
+
+  if (!Array.isArray(content)) {
+    return '';
+  }
+
+  return content
+    .map((part) => {
+      if (typeof part === 'string') {
+        return part;
+      }
+
+      if (!part || typeof part !== 'object') {
+        return '';
+      }
+
+      const partRecord = part as Record<string, unknown>;
+      if (typeof partRecord.text === 'string') {
+        return partRecord.text;
+      }
+
+      if (typeof partRecord.content === 'string') {
+        return partRecord.content;
+      }
+
+      return '';
+    })
+    .join('');
+}
+
+function extractOutputText(response: unknown): string {
+  if (!response || typeof response !== 'object') {
+    return '';
+  }
+
+  const asRecord = response as Record<string, unknown>;
+  const outputText = asRecord.output_text;
+  if (typeof outputText === 'string' && outputText.trim()) {
+    return outputText.trim();
+  }
+
+  const choices = asRecord.choices;
+  if (Array.isArray(choices)) {
+    for (const choice of choices) {
+      if (!choice || typeof choice !== 'object') {
+        continue;
+      }
+
+      const choiceRecord = choice as Record<string, unknown>;
+      const message = choiceRecord.message;
+      if (message && typeof message === 'object') {
+        const content = (message as Record<string, unknown>).content;
+        const text = readTextContent(content).trim();
+        if (text) {
+          return text;
+        }
+      }
+
+      const text = readTextContent(choiceRecord.text).trim();
+      if (text) {
+        return text;
+      }
+    }
+  }
+
+  const output = asRecord.output;
+  if (Array.isArray(output)) {
+    for (const item of output) {
+      if (!item || typeof item !== 'object') {
+        continue;
+      }
+
+      const content = (item as Record<string, unknown>).content;
+      const text = readTextContent(content).trim();
+      if (text) {
+        return text;
+      }
+    }
+  }
+
+  return '';
+}
+
+async function openAICompatibleChat(
+  messages: ChatMessage[],
+  modelConfig: ModelConfig = {},
+  options: ChatCompletionOptions = {}
+): Promise<OpenAIChatResult> {
+  const apiKey = getConfiguredApiKey(modelConfig);
+  const url = resolveChatCompletionsUrl(getConfiguredBaseUrl(modelConfig));
+  const timeoutMs = modelConfig.timeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  const requestBody = {
+    model: getConfiguredModel(modelConfig),
+    messages,
+    temperature: options.temperature ?? modelConfig.temperature ?? 0,
+  };
+
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(requestBody),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(
+        `OpenAI-compatible chat completion request failed: ${response.status} ${response.statusText}: ${errorText.substring(0, 1000)}`
+      );
+    }
+
+    const raw = (await response.json()) as unknown;
+    const text = extractOutputText(raw);
+    if (!text) {
+      throw new Error('OpenAI-compatible response did not contain output text');
+    }
+
+    return { text, raw };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+class OpenAICompatibleChatModel {
+  constructor(private readonly modelConfig: ModelConfig) {}
+
+  async invoke(
+    input: string | ChatMessage[],
+    options?: ChatCompletionOptions
+  ): Promise<{ content: string; raw: unknown }> {
+    const messages =
+      typeof input === 'string'
+        ? [{ role: 'user' as const, content: input }]
+        : input;
+    const result = await openAICompatibleChat(
+      messages,
+      this.modelConfig,
+      options
+    );
+    return { content: result.text, raw: result.raw };
+  }
+}
+
+async function getModel(modelConfig: ModelConfig = {}) {
+  return new OpenAICompatibleChatModel(modelConfig);
+}
+
+function stripSingleCodeFence(text: string): string {
+  const trimmed = text.trim();
+  const fenced = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
+  return fenced?.[1] ? fenced[1].trim() : trimmed;
+}
+
+function parseJsonValue(text: string): any {
+  const normalized = stripSingleCodeFence(text);
+  const candidates = [normalized];
+  const objectStart = normalized.indexOf('{');
+  const objectEnd = normalized.lastIndexOf('}');
+  if (objectStart >= 0 && objectEnd > objectStart) {
+    candidates.push(normalized.slice(objectStart, objectEnd + 1));
+  }
+
+  const arrayStart = normalized.indexOf('[');
+  const arrayEnd = normalized.lastIndexOf(']');
+  if (arrayStart >= 0 && arrayEnd > arrayStart) {
+    candidates.push(normalized.slice(arrayStart, arrayEnd + 1));
+  }
+
+  let lastError: unknown;
+  for (const candidate of [...new Set(candidates)]) {
+    try {
+      return JSON.parse(candidate);
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  console.error('Invalid JSON format Error:', JSON.stringify(lastError));
+  throw new Error(`Invalid JSON format: ${normalized.substring(0, 100)}...`);
 }
 
 /**
  * Custom extractor
  *
- * Extracts JSON content from a string where
- * JSON is embedded between ```json and ``` tags.
+ * Extracts JSON content from a string or model response. It accepts fenced JSON
+ * blocks and direct JSON so OpenAI-compatible providers do not need a heavyweight
+ * output parser dependency.
  */
 const extractJson = (output: any, schema: Schema, returnSingle = true): any => {
-  const text =
-    typeof output === 'string'
-      ? output
-      : ((output.content || output.toString()) as string);
+  if (typeof output !== 'string') {
+    if (validateSchema(output, schema)) {
+      return output;
+    }
+
+    if (output && typeof output === 'object' && 'content' in output) {
+      output = (output as { content?: unknown }).content;
+    }
+  }
+
+  const text = typeof output === 'string' ? output : JSON.stringify(output);
   // Define the regular expression pattern to match JSON blocks
-  const pattern = /```json(.*?)```/gs;
+  const pattern = /```(?:json)?\s*([\s\S]*?)```/gi;
 
   // Find all non-overlapping matches of the pattern in the string
-  const matches = text.match(pattern);
-
-  if (!matches || matches.length === 0) {
-    throw new Error('No JSON blocks found in AI response');
-  }
+  const matches = [...text.matchAll(pattern)];
+  const jsonBlocks =
+    matches.length > 0 ? matches.map((match) => match[1] || '') : [text];
 
   // Process each match, attempting to parse it as JSON
   try {
-    const results = matches.map((match) => {
-      // Remove the markdown code block syntax to isolate the JSON string
-      const jsonStr = match.replace(/```json|```/g, '').trim();
-
-      let jsonData;
-      try {
-        jsonData = JSON.parse(jsonStr);
-      } catch (parseError) {
-        console.error('Invalid JSON format Error:', JSON.stringify(parseError));
-        throw new Error(`Invalid JSON format: ${jsonStr.substring(0, 100)}...`);
-      }
+    const results = jsonBlocks.map((jsonStr) => {
+      const jsonData = parseJsonValue(jsonStr);
 
       const isValid = validateSchema(jsonData, schema);
       if (!isValid) {
@@ -111,18 +344,24 @@ async function fixJsonDataWithAI(
     `;
   const schema = generateSchema(originalData);
   const model = await getModel(modelConfig || {});
-  const parser = new JsonOutputParser();
-  const prompt = new PromptTemplate({
-    template: fixPrompt,
-    inputVariables: ['originalData', 'data', 'schema'],
-  });
-  const chain = prompt.pipe(model).pipe(parser);
-  const result = await chain.invoke({
-    originalData: JSON.stringify(originalData),
-    data: JSON.stringify(data),
-    schema: JSON.stringify(schema),
-  });
-  return extractJson(result, schema);
+  const result = await model.invoke(
+    [
+      {
+        role: 'system',
+        content:
+          'You repair JSON while preserving the exact structure described by the provided schema.',
+      },
+      {
+        role: 'user',
+        content: fixPrompt
+          .replace('{originalData}', JSON.stringify(originalData))
+          .replace('{data}', JSON.stringify(data))
+          .replace('{schema}', JSON.stringify(schema)),
+      },
+    ],
+    { temperature: 0 }
+  );
+  return extractJson(result.content, schema);
 }
 
 /**
@@ -280,36 +519,36 @@ Make sure to wrap the answer in \`\`\`json and \`\`\` tags
 
 `;
 
-  // Initialize the AI model
-  const model = await getModel(modelConfig || {});
-
-  // Create the prompt template with input variables
-  const prompt = new PromptTemplate({
-    template: suggestPrompt,
-    inputVariables: ['data', 'methodology', 'schema'],
-  });
-
   // Generate schema from the input data to ensure structure preservation
   const schema = generateSchema(data);
 
-  // Create parser for JSON output
-  const parser = new JsonOutputParser();
-
-  // Build the processing chain
-  const chain = prompt.pipe(model).pipe(parser);
+  // Initialize the AI model
+  const model = await getModel(modelConfig || {});
 
   // Invoke the AI model with the formatted inputs
-  const result = await chain.invoke({
-    data: JSON.stringify(data),
-    methodology: JSON.stringify(methodology),
-    schema: JSON.stringify(schema),
-  });
+  const result = await model.invoke(
+    [
+      {
+        role: 'system',
+        content:
+          'You improve TIDAS/LCA JSON content and return only valid JSON with the original structure preserved.',
+      },
+      {
+        role: 'user',
+        content: suggestPrompt
+          .replace('{data}', JSON.stringify(data))
+          .replace('{methodology}', JSON.stringify(methodology))
+          .replace('{schema}', JSON.stringify(schema)),
+      },
+    ],
+    { temperature: modelConfig?.temperature ?? 0 }
+  );
 
   // Log performance metrics
   const endTime = Date.now();
   console.log(`Suggestion took ${endTime - startTime}ms`);
 
-  return result;
+  return extractJson(result.content, schema);
 }
 
 /**
@@ -392,102 +631,58 @@ Provide a detailed review with the following structure:
 
 Output your answer as JSON in this exact format:
 \`\`\`json
-{{
+{
   "review_comment": "Your detailed review here",
   "review_score": 75
-}}
+}
 \`\`\`
 `;
 
-  // Initialize the AI model with structured output
+  // Initialize the AI model
   const model = await getModel(modelConfig || {});
-
-  // Define the output schema using Zod
-  const { z } = await import('zod');
-  const reviewSchema = z.object({
-    review_comment: z
-      .string()
-      .describe(
-        'Detailed review comment with compliance assessment and suggestions'
-      ),
-    review_score: z
-      .number()
-      .min(0)
-      .max(100)
-      .describe('Compliance score from 0-100'),
-  });
-
-  // Configure model with structured output
-  const modelWithStructure = model.withStructuredOutput(reviewSchema, {
-    name: 'review_output',
-  });
-
-  // Create the prompt template with input variables
-  const prompt = new PromptTemplate({
-    template: reviewPrompt,
-    inputVariables: ['data', 'methodology'],
-  });
-
-  // Build the processing chain
-  const chain = prompt.pipe(modelWithStructure);
+  const reviewSchema: Schema = {
+    type: 'object',
+    properties: {
+      review_comment: { type: 'string' },
+      review_score: { type: 'number' },
+    },
+  };
 
   try {
     // Invoke the AI model with the formatted inputs
-    const result = await chain.invoke({
-      data: JSON.stringify(data, null, 2),
-      methodology: JSON.stringify(methodology, null, 2),
-    });
+    const result = await model.invoke(
+      [
+        {
+          role: 'system',
+          content:
+            'You review TIDAS/LCA JSON against methodology rules and return only valid JSON.',
+        },
+        {
+          role: 'user',
+          content: reviewPrompt
+            .replace('{data}', JSON.stringify(data, null, 2))
+            .replace('{methodology}', JSON.stringify(methodology, null, 2)),
+        },
+      ],
+      { temperature: modelConfig?.temperature ?? 0 }
+    );
+    const parsed = extractJson(result.content, reviewSchema) as {
+      review_comment: string;
+      review_score: number;
+    };
+
+    if (parsed.review_score < 0 || parsed.review_score > 100) {
+      throw new Error('Review score must be between 0 and 100');
+    }
 
     // Log performance metrics
     const endTime = Date.now();
     console.log(`Review completed in ${endTime - startTime}ms`);
-    console.log(`Review score: ${result.review_score}/100`);
+    console.log(`Review score: ${parsed.review_score}/100`);
 
-    return result;
+    return parsed;
   } catch (error) {
-    console.error('Review failed:', error);
-
-    // Fallback to parsing from regular output if structured output fails
-    try {
-      const prompt = new PromptTemplate({
-        template: reviewPrompt,
-        inputVariables: ['data', 'methodology'],
-      });
-
-      const chain = prompt.pipe(model);
-      const result = await chain.invoke({
-        data: JSON.stringify(data, null, 2),
-        methodology: JSON.stringify(methodology, null, 2),
-      });
-
-      // Extract JSON from the response
-      const text = result.content as string;
-      const jsonMatch = text.match(/```json\s*([\s\S]*?)\s*```/);
-      if (jsonMatch && jsonMatch[1]) {
-        const parsed = JSON.parse(jsonMatch[1]);
-
-        // Validate the structure
-        if (
-          typeof parsed.review_comment === 'string' &&
-          typeof parsed.review_score === 'number' &&
-          parsed.review_score >= 0 &&
-          parsed.review_score <= 100
-        ) {
-          const endTime = Date.now();
-          console.log(
-            `Review completed in ${endTime - startTime}ms (fallback mode)`
-          );
-          console.log(`Review score: ${parsed.review_score}/100`);
-          return parsed;
-        }
-      }
-
-      throw new Error(
-        'Failed to extract valid review structure from AI response'
-      );
-    } catch (fallbackError) {
-      throw new Error(`Review failed: ${(fallbackError as Error).message}`);
-    }
+    throw new Error(`Review failed: ${(error as Error).message}`);
   }
 }
 
@@ -525,6 +720,7 @@ export async function suggestEntireObject(
   options?: {
     skipPaths?: string[];
     maxRetries?: number;
+    modelConfig?: ModelConfig;
   }
 ): Promise<any> {
   const startTime = Date.now();
@@ -629,7 +825,11 @@ export async function suggestEntireObject(
       // Apply suggestion with retry
       for (let retry = 1; retry <= opts.maxRetries; retry++) {
         try {
-          const suggestedValue = await suggest(currentValue, rule);
+          const suggestedValue = await suggest(
+            currentValue,
+            rule,
+            opts.modelConfig
+          );
 
           // Validate structure is preserved
           const originalSchema = generateSchema(currentValue);

--- a/sdks/typescript/src/runtime-assets/tidas/methodologies/runtime_rulesets.json
+++ b/sdks/typescript/src/runtime-assets/tidas/methodologies/runtime_rulesets.json
@@ -1,0 +1,378 @@
+{
+  "$schema": "runtime_rulesets.schema.json",
+  "schema_version": 1,
+  "ruleset_version": "2026.05.23",
+  "purpose": "Runtime-friendly metadata for CLI and Foundry gates. This file assigns stable rule ids, severity, phases, blocker defaults, and source references to packaged TIDAS methodology assets.",
+  "source_assets": [
+    {
+      "asset": "tidas_processes.yaml",
+      "kind": "process methodology"
+    },
+    {
+      "asset": "tidas_flows.yaml",
+      "kind": "flow methodology"
+    }
+  ],
+  "rulesets": [
+    {
+      "id": "process-authoring/strict",
+      "version": "1",
+      "dataset_type": "process",
+      "phase": "authoring",
+      "rule_ids": [
+        "tidas.process.name.base-name.align-reference-flow",
+        "tidas.process.name.qualifiers.structured",
+        "tidas.process.quantitative-reference.required",
+        "tidas.process.exchange.amount.required",
+        "tidas.process.evidence.field-bindings.required"
+      ]
+    },
+    {
+      "id": "process-authoring/repair",
+      "version": "1",
+      "dataset_type": "process",
+      "phase": "repair",
+      "rule_ids": [
+        "tidas.process.quantitative-reference.required",
+        "tidas.process.exchange.amount.required",
+        "tidas.process.evidence.field-bindings.required",
+        "tidas.process.version.format"
+      ]
+    },
+    {
+      "id": "process-publish/default",
+      "version": "1",
+      "dataset_type": "process",
+      "phase": "publish",
+      "rule_ids": [
+        "tidas.process.name.base-name.align-reference-flow",
+        "tidas.process.quantitative-reference.required",
+        "tidas.process.exchange.amount.required",
+        "tidas.process.evidence.field-bindings.required",
+        "tidas.process.version.format"
+      ]
+    },
+    {
+      "id": "process-dedup/default",
+      "version": "1",
+      "dataset_type": "process",
+      "phase": "identity",
+      "rule_ids": [
+        "tidas.process.identity.duplicate-fingerprint.block"
+      ]
+    },
+    {
+      "id": "flow-authoring/strict",
+      "version": "1",
+      "dataset_type": "flow",
+      "phase": "authoring",
+      "rule_ids": [
+        "tidas.flow.name.base-name.technical",
+        "tidas.flow.type.required",
+        "tidas.flow.reference-property-unit.required",
+        "tidas.flow.flow-property.mean-value.positive",
+        "tidas.flow.evidence.field-bindings.required"
+      ]
+    },
+    {
+      "id": "flow-publish/default",
+      "version": "1",
+      "dataset_type": "flow",
+      "phase": "publish",
+      "rule_ids": [
+        "tidas.flow.name.base-name.technical",
+        "tidas.flow.type.required",
+        "tidas.flow.reference-property-unit.required",
+        "tidas.flow.classification.elementary.valid",
+        "tidas.flow.flow-property.mean-value.positive",
+        "tidas.flow.evidence.field-bindings.required"
+      ]
+    },
+    {
+      "id": "flow-dedup/default",
+      "version": "1",
+      "dataset_type": "flow",
+      "phase": "identity",
+      "rule_ids": [
+        "tidas.flow.identity.alias-equivalence.review"
+      ]
+    }
+  ],
+  "rules": [
+    {
+      "id": "tidas.process.name.base-name.align-reference-flow",
+      "dataset_type": "process",
+      "summary": "Process baseName should align with the reference flow naming structure and avoid geography or time qualifiers.",
+      "severity": "blocker",
+      "phases": ["build-plan", "materialize", "publish-build", "save-draft", "publish-run"],
+      "default_blocker": true,
+      "field_paths": [
+        "processDataSet.processInformation.dataSetInformation.name.baseName"
+      ],
+      "source_rule_refs": [
+        {
+          "asset": "tidas_processes.yaml",
+          "path": "processDataSet.processInformation.dataSetInformation.name.baseName.<rules>"
+        }
+      ]
+    },
+    {
+      "id": "tidas.process.name.qualifiers.structured",
+      "dataset_type": "process",
+      "summary": "Process name qualifiers should separate treatment, standards, mix/location, and quantitative properties into the dedicated name segments.",
+      "severity": "warning",
+      "phases": ["build-plan", "materialize", "publish-build"],
+      "default_blocker": false,
+      "field_paths": [
+        "processDataSet.processInformation.dataSetInformation.name.treatmentStandardsRoutes",
+        "processDataSet.processInformation.dataSetInformation.name.mixAndLocationTypes",
+        "processDataSet.processInformation.dataSetInformation.name.functionalUnitFlowProperties"
+      ],
+      "source_rule_refs": [
+        {
+          "asset": "tidas_processes.yaml",
+          "path": "processDataSet.processInformation.dataSetInformation.name.treatmentStandardsRoutes.<rules>"
+        },
+        {
+          "asset": "tidas_processes.yaml",
+          "path": "processDataSet.processInformation.dataSetInformation.name.mixAndLocationTypes.<rules>"
+        },
+        {
+          "asset": "tidas_processes.yaml",
+          "path": "processDataSet.processInformation.dataSetInformation.name.functionalUnitFlowProperties.<rules>"
+        }
+      ]
+    },
+    {
+      "id": "tidas.process.quantitative-reference.required",
+      "dataset_type": "process",
+      "summary": "A process must identify a quantitative reference exchange or reference flow before authoring or publishing.",
+      "severity": "blocker",
+      "phases": ["build-plan", "materialize", "publish-build", "save-draft", "publish-run"],
+      "default_blocker": true,
+      "field_paths": [
+        "processDataSet.exchanges.exchange[*].@dataSetInternalID",
+        "processDataSet.exchanges.exchange[*].referenceToFlowDataSet"
+      ],
+      "source_rule_refs": [
+        {
+          "asset": "tidas_processes.yaml",
+          "path": "processDataSet.exchanges.exchange.referenceToFlowDataSet.<rules>"
+        }
+      ]
+    },
+    {
+      "id": "tidas.process.exchange.amount.required",
+      "dataset_type": "process",
+      "summary": "Each exchange needs meanAmount or resultingAmount evidence before it can be treated as publish-ready.",
+      "severity": "blocker",
+      "phases": ["build-plan", "materialize", "publish-build", "save-draft", "publish-run"],
+      "default_blocker": true,
+      "field_paths": [
+        "processDataSet.exchanges.exchange[*].meanAmount",
+        "processDataSet.exchanges.exchange[*].resultingAmount"
+      ],
+      "source_rule_refs": [
+        {
+          "asset": "tidas_processes.yaml",
+          "path": "processDataSet.exchanges.exchange.meanAmount.<rules>"
+        }
+      ]
+    },
+    {
+      "id": "tidas.process.evidence.field-bindings.required",
+      "dataset_type": "process",
+      "summary": "Process authoring and publish gates require evidence bindings for identity, names, quantitative reference, exchanges, source, geography, time, and technology.",
+      "severity": "blocker",
+      "phases": ["build-plan", "materialize", "publish-build", "publish-run"],
+      "default_blocker": true,
+      "field_paths": [
+        "EvidenceManifest.sources",
+        "EvidenceManifest.field_bindings"
+      ],
+      "source_rule_refs": [
+        {
+          "asset": "tidas_processes.yaml",
+          "path": "processDataSet.processInformation.technology.technologyDescriptionAndIncludedProcesses.<rules>"
+        },
+        {
+          "asset": "tidas_processes.yaml",
+          "path": "processDataSet.modellingAndValidation.dataSourcesTreatmentAndRepresentativeness.dataCollectionPeriod.<rules>"
+        }
+      ]
+    },
+    {
+      "id": "tidas.process.version.format",
+      "dataset_type": "process",
+      "summary": "Process dataset versions must use fixed-width ILCD three-tier numbering and increase when content changes.",
+      "severity": "blocker",
+      "phases": ["save-draft", "publish-build", "publish-run"],
+      "default_blocker": true,
+      "field_paths": [
+        "processDataSet.administrativeInformation.publicationAndOwnership.common:dataSetVersion"
+      ],
+      "source_rule_refs": [
+        {
+          "asset": "tidas_processes.yaml",
+          "path": "processDataSet.administrativeInformation.publicationAndOwnership.common:dataSetVersion.<rules>"
+        }
+      ]
+    },
+    {
+      "id": "tidas.process.identity.duplicate-fingerprint.block",
+      "dataset_type": "process",
+      "summary": "A new process is blocked when reference flow, route, geography, system boundary, and exchange fingerprint are equivalent to an existing candidate.",
+      "severity": "blocker",
+      "phases": ["identity-preflight", "dedup-review"],
+      "default_blocker": true,
+      "field_paths": [
+        "IdentityDecision.decision",
+        "ProcessIdentity.reference_flow",
+        "ProcessIdentity.exchange_fingerprint"
+      ],
+      "source_rule_refs": [
+        {
+          "asset": "tidas_processes.yaml",
+          "path": "processDataSet.exchanges.exchange.referenceToFlowDataSet.<rules>"
+        },
+        {
+          "asset": "tidas_processes.yaml",
+          "path": "processDataSet.processInformation.dataSetInformation.name.<rules>"
+        }
+      ]
+    },
+    {
+      "id": "tidas.flow.name.base-name.technical",
+      "dataset_type": "flow",
+      "summary": "Flow baseName must use technical terminology and avoid geography, time, or quantitative qualifiers that belong in dedicated fields.",
+      "severity": "blocker",
+      "phases": ["build-plan", "materialize", "publish-build", "save-draft", "publish-run"],
+      "default_blocker": true,
+      "field_paths": [
+        "flowDataSet.flowInformation.dataSetInformation.name.baseName"
+      ],
+      "source_rule_refs": [
+        {
+          "asset": "tidas_flows.yaml",
+          "path": "flowDataSet.flowInformation.dataSetInformation.name.baseName.<rules>"
+        }
+      ]
+    },
+    {
+      "id": "tidas.flow.type.required",
+      "dataset_type": "flow",
+      "summary": "Flow datasets must declare Elementary flow, Product flow, or Waste flow consistently with classification and reference property.",
+      "severity": "blocker",
+      "phases": ["build-plan", "materialize", "publish-build", "save-draft", "publish-run"],
+      "default_blocker": true,
+      "field_paths": [
+        "flowDataSet.modellingAndValidation.LCIMethod.typeOfDataSet"
+      ],
+      "source_rule_refs": [
+        {
+          "asset": "tidas_flows.yaml",
+          "path": "flowDataSet.modellingAndValidation.LCIMethod.typeOfDataSet.<rules>"
+        }
+      ]
+    },
+    {
+      "id": "tidas.flow.reference-property-unit.required",
+      "dataset_type": "flow",
+      "summary": "Flow authoring must provide a reference flow property and reference unit before schema or publish gates can pass.",
+      "severity": "blocker",
+      "phases": ["build-plan", "materialize", "publish-build", "save-draft", "publish-run"],
+      "default_blocker": true,
+      "field_paths": [
+        "flowDataSet.flowProperties.flowProperty[*].referenceToFlowPropertyDataSet",
+        "flowDataSet.flowProperties.flowProperty[*].referenceUnit"
+      ],
+      "source_rule_refs": [
+        {
+          "asset": "tidas_flows.yaml",
+          "path": "flowDataSet.flowInformation.dataSetInformation.name.flowProperties.<rules>"
+        }
+      ]
+    },
+    {
+      "id": "tidas.flow.flow-property.mean-value.positive",
+      "dataset_type": "flow",
+      "summary": "Flow property mean values must be positive real numbers and the quantitative reference property should use 1.0.",
+      "severity": "blocker",
+      "phases": ["materialize", "publish-build", "save-draft", "publish-run"],
+      "default_blocker": true,
+      "field_paths": [
+        "flowDataSet.flowProperties.flowProperty[*].meanValue"
+      ],
+      "source_rule_refs": [
+        {
+          "asset": "tidas_flows.yaml",
+          "path": "flowDataSet.flowProperties.flowProperty.meanValue.<rules>"
+        }
+      ]
+    },
+    {
+      "id": "tidas.flow.classification.elementary.valid",
+      "dataset_type": "flow",
+      "summary": "Elementary flow classification must use the controlled category hierarchy with continuous levels and valid category ids.",
+      "severity": "blocker",
+      "phases": ["materialize", "publish-build", "save-draft", "publish-run"],
+      "default_blocker": true,
+      "field_paths": [
+        "flowDataSet.flowInformation.dataSetInformation.classificationInformation.common:elementaryFlowCategorization"
+      ],
+      "source_rule_refs": [
+        {
+          "asset": "tidas_flows.yaml",
+          "path": "flowDataSet.flowInformation.dataSetInformation.classificationInformation.common:elementaryFlowCategorization.<rules>"
+        }
+      ]
+    },
+    {
+      "id": "tidas.flow.evidence.field-bindings.required",
+      "dataset_type": "flow",
+      "summary": "Flow authoring and publish gates require evidence bindings for identity, flow type, name, property, unit, classification, and source.",
+      "severity": "blocker",
+      "phases": ["build-plan", "materialize", "publish-build", "publish-run"],
+      "default_blocker": true,
+      "field_paths": [
+        "EvidenceManifest.sources",
+        "EvidenceManifest.field_bindings"
+      ],
+      "source_rule_refs": [
+        {
+          "asset": "tidas_flows.yaml",
+          "path": "flowDataSet.flowInformation.dataSetInformation.name.<rules>"
+        },
+        {
+          "asset": "tidas_flows.yaml",
+          "path": "flowDataSet.flowProperties.flowProperty.<rules>"
+        }
+      ]
+    },
+    {
+      "id": "tidas.flow.identity.alias-equivalence.review",
+      "dataset_type": "flow",
+      "summary": "Flow identity preflight should reuse or review flows with equivalent type, property, unit, CAS/category, synonyms, and aliases.",
+      "severity": "warning",
+      "phases": ["identity-preflight", "dedup-review"],
+      "default_blocker": false,
+      "field_paths": [
+        "IdentityDecision.decision",
+        "FlowIdentity.flow_type",
+        "FlowIdentity.reference_property",
+        "FlowIdentity.reference_unit",
+        "FlowIdentity.aliases"
+      ],
+      "source_rule_refs": [
+        {
+          "asset": "tidas_flows.yaml",
+          "path": "flowDataSet.flowInformation.dataSetInformation.name.common:synonyms.<rules>"
+        },
+        {
+          "asset": "tidas_flows.yaml",
+          "path": "flowDataSet.flowProperties.flowProperty.<rules>"
+        }
+      ]
+    }
+  ]
+}

--- a/sdks/typescript/src/runtime-assets/tidas/methodologies/runtime_rulesets.schema.json
+++ b/sdks/typescript/src/runtime-assets/tidas/methodologies/runtime_rulesets.schema.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://tiangong-lca.local/tidas/runtime-rulesets.schema.json",
+  "title": "TIDAS Runtime Ruleset Metadata",
+  "type": "object",
+  "required": ["schema_version", "ruleset_version", "source_assets", "rulesets", "rules"],
+  "additionalProperties": true,
+  "properties": {
+    "schema_version": { "type": "integer", "minimum": 1 },
+    "ruleset_version": { "type": "string" },
+    "source_assets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["asset", "kind"],
+        "additionalProperties": true,
+        "properties": {
+          "asset": { "type": "string" },
+          "kind": { "type": "string" }
+        }
+      }
+    },
+    "rulesets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "version", "dataset_type", "phase", "rule_ids"],
+        "additionalProperties": true,
+        "properties": {
+          "id": { "type": "string" },
+          "version": { "type": "string" },
+          "dataset_type": { "type": "string", "enum": ["process", "flow"] },
+          "phase": { "type": "string" },
+          "rule_ids": {
+            "type": "array",
+            "items": { "type": "string" },
+            "minItems": 1
+          }
+        }
+      }
+    },
+    "rules": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "id",
+          "dataset_type",
+          "summary",
+          "severity",
+          "phases",
+          "default_blocker",
+          "field_paths",
+          "source_rule_refs"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "id": { "type": "string" },
+          "dataset_type": { "type": "string", "enum": ["process", "flow"] },
+          "summary": { "type": "string" },
+          "severity": { "type": "string", "enum": ["info", "warning", "blocker"] },
+          "phases": {
+            "type": "array",
+            "items": { "type": "string" },
+            "minItems": 1
+          },
+          "default_blocker": { "type": "boolean" },
+          "field_paths": {
+            "type": "array",
+            "items": { "type": "string" },
+            "minItems": 1
+          },
+          "source_rule_refs": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["asset", "path"],
+              "additionalProperties": true,
+              "properties": {
+                "asset": { "type": "string" },
+                "path": { "type": "string" }
+              }
+            },
+            "minItems": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/sdks/typescript/src/services/copilot-service.ts
+++ b/sdks/typescript/src/services/copilot-service.ts
@@ -217,6 +217,7 @@ export async function suggestData(
         {
           skipPaths: options?.skipPaths,
           maxRetries: options?.maxRetries,
+          modelConfig: options?.modelConfig,
         }
       );
 


### PR DESCRIPTION
## Summary

- Replaced the TypeScript SDK copilot LangChain integration with a native OpenAI-compatible `/chat/completions` HTTP client.
- Removed `langchain` / `@langchain/core` dependency entries and lockfile transitive packages.
- Threaded `modelConfig` through SDK suggestion paths, including `baseURL`/`baseUrl`, `model`, `apiKey`, `temperature`, and `timeoutMs`.
- Bumped the TypeScript SDK package to `0.1.41` for the next patch release.
- Added focused tests and README-zh guidance for OpenAI-compatible API configuration.
- Included the `runtime_rulesets*.json` runtime assets generated by CI's default latest `tidas-tools` sync path.

Closes #73

## Benchmark

- Local mock OpenAI-compatible endpoint, 200 measured calls after warmup on Node `v24.16.0`: LangChain mean `0.283 ms`, median `0.254 ms`, p95 `0.426 ms`; native HTTP mean `0.137 ms`, median `0.125 ms`, p95 `0.182 ms`. Mean speedup was about `2.08x`.
- Cold module load benchmark: LangChain mean `68.3 ms`; native implementation mean `1.20 ms`, about `57x` faster.
- Small real OpenAI API sample, model `gpt-4.1-mini`, 3 calls each: LangChain mean `797.1 ms`; native HTTP mean `625.9 ms`, about `1.27x` faster. Network/model latency dominates this path, so treat this as directional rather than a stable SLA.

## Validation

- Node `v24.16.0`, npm `11.13.0`.
- `./scripts/ci/verify-typescript-package.sh` passed with CI-equivalent default latest `tidas-tools` sync.
- `TIDAS_TOOLS_SOURCE_MODE=auto ./scripts/ci/verify-typescript-package.sh` passed using the local sibling `tidas-tools` checkout.
- `./scripts/docpact lint --root /Users/biao/Code/lca-workspace/lca-workspace/tidas-sdk --worktree --format json --output .docpact/runs/latest.json` passed.
- `npm ls langchain @langchain/core @langchain/openai` showed no installed LangChain packages.
- `rg "langchain|@langchain|LangChain|PromptTemplate|JsonOutputParser|ChatOpenAI|withStructuredOutput" sdks/typescript/package.json sdks/typescript/package-lock.json sdks/typescript/src sdks/typescript/dist` found no references.

## Notes

The original CI failure was caused by generation stability under the default latest `tidas-tools` sync path, which produced untracked `runtime_rulesets*.json` assets. Those generated assets are now committed in this PR.

After merge, publish by creating/pushing `typescript-v0.1.41` so the npm release workflow can publish the package.