### PR TITLE
Gate SDK releases with local doc checks

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-27"
-lastReviewedCommit: "02724b146504f2cae725e736a0017136c0122412"
+lastReviewedAt: "2026-05-28"
+lastReviewedCommit: "d7b9e3eb06c279e9a1c09e76eece9a75ed694cc3"
 
 catalog:
   repos:

--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -1,7 +1,7 @@
 name: ai-doc-lint
 
 on:
-  pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -16,19 +16,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Fetch main
+        run: git fetch --force origin +refs/heads/main:refs/remotes/origin/main
+
       - name: Install stable Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install docpact
         run: cargo install docpact --version 0.1.9 --force
 
-      - name: Validate docpact config
-        run: scripts/docpact validate-config --root . --strict
-
-      - name: Run docpact lint
-        run: >
-          scripts/docpact lint
-          --root .
-          --base "${{ github.event.pull_request.base.sha }}"
-          --head "${{ github.event.pull_request.head.sha }}"
-          --mode enforce
+      - name: Run local docpact gate
+        run: scripts/docpact-gate.sh --base origin/main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,9 +10,32 @@ permissions:
   contents: read
 
 jobs:
+  release-gate:
+    name: Release Gate
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Fetch main
+        run: git fetch --force origin +refs/heads/main:refs/remotes/origin/main
+
+      - name: Install stable Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install docpact
+        run: cargo install docpact --version 0.1.9 --force
+
+      - name: Run docpact release gate
+        run: scripts/docpact-gate.sh --base origin/main
+
   typescript-publish:
     name: Publish TypeScript package
     if: startsWith(github.ref_name, 'typescript-v')
+    needs: release-gate
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -49,6 +72,7 @@ jobs:
   python-build:
     name: Build Python distributions
     if: startsWith(github.ref_name, 'python-v')
+    needs: release-gate
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/tag-release-from-merge.yml
+++ b/.github/workflows/tag-release-from-merge.yml
@@ -20,12 +20,29 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install stable Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install docpact
+        run: cargo install docpact --version 0.1.9 --force
+
       - name: Validate automation token
         run: |
           if [ -z "$GH_TOKEN" ]; then
             echo "error: missing TIDAS_RELEASE_AUTOMATION_TOKEN secret" >&2
             exit 1
           fi
+
+      - name: Run docpact release gate before tag
+        env:
+          BASE_REF: ${{ github.event.before }}
+          HEAD_REF: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [ "$BASE_REF" = "0000000000000000000000000000000000000000" ]; then
+            BASE_REF="${HEAD_REF}^"
+          fi
+          scripts/docpact-gate.sh --base "$BASE_REF" --head "$HEAD_REF"
 
       - name: Detect release version changes
         id: release

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ Read in this order:
 - path-level ownership, routing intents, governed-doc inventory, and lint rules live in `.docpact/config.yaml`
 - minimum proof and upstream-resolution notes live in `docs/agents/repo-validation.md`
 - stable path groups, upstream handoffs, and release topology live in `docs/agents/repo-architecture.md`
-- repo-local documentation maintenance is enforced by `.github/workflows/ai-doc-lint.yml` with `docpact lint`
+- repo-local documentation maintenance is enforced locally by the pre-push docpact gate; `.github/workflows/ai-doc-lint.yml` is manual-dispatch fallback
 - the main routing intents are `typescript-sdk`, `validation-contract`, `python-sdk`, `generation-and-release`, `upstream-refresh`, `release-setup`, `proof`, `repo-docs`, and `root-integration`
 - TypeScript validation normalization is owned by `sdks/typescript/src/core/config/ValidationConfig.ts`, while schema-level custom issue codes for generated localized-text checks are injected from `sdks/typescript/scripts/generate-zod-schemas.ts` into committed schema output under `sdks/typescript/src/schemas/**`
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ checkPaths:
   - sdks/typescript/**
   - sdks/python/**
   - scripts/ci/**
-lastReviewedAt: 2026-05-22
-lastReviewedCommit: 893aa12cab10d0a6791e8c8aa42bb2624d665ee8
+lastReviewedAt: 2026-05-28
+lastReviewedCommit: d7b9e3eb06c279e9a1c09e76eece9a75ed694cc3
 ---
 
 # TIDAS SDKs

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -25,8 +25,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-25
-lastReviewedCommit: 02724b146504f2cae725e736a0017136c0122412
+lastReviewedAt: 2026-05-28
+lastReviewedCommit: d7b9e3eb06c279e9a1c09e76eece9a75ed694cc3
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -27,8 +27,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-25
-lastReviewedCommit: 02724b146504f2cae725e736a0017136c0122412
+lastReviewedAt: 2026-05-28
+lastReviewedCommit: d7b9e3eb06c279e9a1c09e76eece9a75ed694cc3
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -16,8 +16,8 @@ checkPaths:
   - .github/workflows/publish.yml
   - .github/workflows/tag-release-from-merge.yml
   - .docpact/config.yaml
-lastReviewedAt: 2026-05-25
-lastReviewedCommit: 02724b146504f2cae725e736a0017136c0122412
+lastReviewedAt: 2026-05-28
+lastReviewedCommit: d7b9e3eb06c279e9a1c09e76eece9a75ed694cc3
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/upstream-automation.md
+++ b/docs/upstream-automation.md
@@ -17,8 +17,8 @@ checkPaths:
   - .github/workflows/sync-from-tidas-tools.yml
   - .github/workflows/tag-release-from-merge.yml
   - .docpact/config.yaml
-lastReviewedAt: 2026-05-25
-lastReviewedCommit: 02724b146504f2cae725e736a0017136c0122412
+lastReviewedAt: 2026-05-28
+lastReviewedCommit: d7b9e3eb06c279e9a1c09e76eece9a75ed694cc3
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml


### PR DESCRIPTION
## Summary
- move ai-doc-lint off ordinary PR/push execution and keep it as manual fallback
- keep documentation governance in the local pre-push gate
- add docpact gates before automatic release tagging and package publish

## Validation
- parsed changed GitHub workflow YAML locally
- ran repo docpact/AI-doc gate against origin/main..HEAD
- ran local test gate where the repo pre-push hook required it

Closes #77
