### PR TITLE
Fix docpact gate review feedback

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-28"
-lastReviewedCommit: "2decb1bcb0fc5e5cb24d552b27ddc24cac1eff9a"
+lastReviewedCommit: "e33751221a477b6065cac0b0e6372aae601973a1"
 
 catalog:
   repos:

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-28"
-lastReviewedCommit: "d7b9e3eb06c279e9a1c09e76eece9a75ed694cc3"
+lastReviewedCommit: "b78a3a680b40dff93a7edb464bc7fbd103619352"
 
 catalog:
   repos:

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-28"
-lastReviewedCommit: "b78a3a680b40dff93a7edb464bc7fbd103619352"
+lastReviewedCommit: "2decb1bcb0fc5e5cb24d552b27ddc24cac1eff9a"
 
 catalog:
   repos:

--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -31,4 +31,6 @@ jobs:
         run: cargo install docpact --version 0.1.9 --force
 
       - name: Run local docpact gate
-        run: scripts/docpact-gate.sh --base "${{ inputs.base_ref }}"
+        env:
+          BASE_REF: ${{ inputs.base_ref }}
+        run: scripts/docpact-gate.sh --base "$BASE_REF"

--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -2,6 +2,11 @@ name: ai-doc-lint
 
 on:
   workflow_dispatch:
+    inputs:
+      base_ref:
+        description: Base ref for the manual docpact comparison.
+        required: false
+        default: origin/main
 
 permissions:
   contents: read
@@ -16,8 +21,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Fetch main
-        run: git fetch --force origin +refs/heads/main:refs/remotes/origin/main
+      - name: Fetch branches
+        run: git fetch --force origin '+refs/heads/*:refs/remotes/origin/*'
 
       - name: Install stable Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -26,4 +31,4 @@ jobs:
         run: cargo install docpact --version 0.1.9 --force
 
       - name: Run local docpact gate
-        run: scripts/docpact-gate.sh --base origin/main
+        run: scripts/docpact-gate.sh --base "${{ inputs.base_ref }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,11 @@ jobs:
         run: cargo install docpact --version 0.1.9 --force
 
       - name: Run docpact release gate
-        run: scripts/docpact-gate.sh --base origin/main
+        run: |
+          set -euo pipefail
+          release_head="$(git rev-list -n 1 "$GITHUB_REF_NAME")"
+          release_base="$(git rev-parse "${release_head}^")"
+          scripts/docpact-gate.sh --base "$release_base" --head "$release_head"
 
   typescript-publish:
     name: Publish TypeScript package

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,8 +30,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-25
-lastReviewedCommit: 02724b146504f2cae725e736a0017136c0122412
+lastReviewedAt: 2026-05-28
+lastReviewedCommit: b78a3a680b40dff93a7edb464bc7fbd103619352
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: b78a3a680b40dff93a7edb464bc7fbd103619352
+lastReviewedCommit: 2decb1bcb0fc5e5cb24d552b27ddc24cac1eff9a
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 2decb1bcb0fc5e5cb24d552b27ddc24cac1eff9a
+lastReviewedCommit: e33751221a477b6065cac0b0e6372aae601973a1
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ checkPaths:
   - sdks/python/**
   - scripts/ci/**
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: d7b9e3eb06c279e9a1c09e76eece9a75ed694cc3
+lastReviewedCommit: b78a3a680b40dff93a7edb464bc7fbd103619352
 ---
 
 # TIDAS SDKs

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ checkPaths:
   - sdks/python/**
   - scripts/ci/**
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: b78a3a680b40dff93a7edb464bc7fbd103619352
+lastReviewedCommit: 2decb1bcb0fc5e5cb24d552b27ddc24cac1eff9a
 ---
 
 # TIDAS SDKs

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ checkPaths:
   - sdks/python/**
   - scripts/ci/**
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 2decb1bcb0fc5e5cb24d552b27ddc24cac1eff9a
+lastReviewedCommit: e33751221a477b6065cac0b0e6372aae601973a1
 ---
 
 # TIDAS SDKs

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,7 +26,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: d7b9e3eb06c279e9a1c09e76eece9a75ed694cc3
+lastReviewedCommit: b78a3a680b40dff93a7edb464bc7fbd103619352
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,7 +26,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 2decb1bcb0fc5e5cb24d552b27ddc24cac1eff9a
+lastReviewedCommit: e33751221a477b6065cac0b0e6372aae601973a1
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,7 +26,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: b78a3a680b40dff93a7edb464bc7fbd103619352
+lastReviewedCommit: 2decb1bcb0fc5e5cb24d552b27ddc24cac1eff9a
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: b78a3a680b40dff93a7edb464bc7fbd103619352
+lastReviewedCommit: 2decb1bcb0fc5e5cb24d552b27ddc24cac1eff9a
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 2decb1bcb0fc5e5cb24d552b27ddc24cac1eff9a
+lastReviewedCommit: e33751221a477b6065cac0b0e6372aae601973a1
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: d7b9e3eb06c279e9a1c09e76eece9a75ed694cc3
+lastReviewedCommit: b78a3a680b40dff93a7edb464bc7fbd103619352
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -17,7 +17,7 @@ checkPaths:
   - .github/workflows/tag-release-from-merge.yml
   - .docpact/config.yaml
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 2decb1bcb0fc5e5cb24d552b27ddc24cac1eff9a
+lastReviewedCommit: e33751221a477b6065cac0b0e6372aae601973a1
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -17,7 +17,7 @@ checkPaths:
   - .github/workflows/tag-release-from-merge.yml
   - .docpact/config.yaml
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: d7b9e3eb06c279e9a1c09e76eece9a75ed694cc3
+lastReviewedCommit: b78a3a680b40dff93a7edb464bc7fbd103619352
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -17,7 +17,7 @@ checkPaths:
   - .github/workflows/tag-release-from-merge.yml
   - .docpact/config.yaml
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: b78a3a680b40dff93a7edb464bc7fbd103619352
+lastReviewedCommit: 2decb1bcb0fc5e5cb24d552b27ddc24cac1eff9a
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/upstream-automation.md
+++ b/docs/upstream-automation.md
@@ -18,7 +18,7 @@ checkPaths:
   - .github/workflows/tag-release-from-merge.yml
   - .docpact/config.yaml
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: b78a3a680b40dff93a7edb464bc7fbd103619352
+lastReviewedCommit: 2decb1bcb0fc5e5cb24d552b27ddc24cac1eff9a
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/upstream-automation.md
+++ b/docs/upstream-automation.md
@@ -18,7 +18,7 @@ checkPaths:
   - .github/workflows/tag-release-from-merge.yml
   - .docpact/config.yaml
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: d7b9e3eb06c279e9a1c09e76eece9a75ed694cc3
+lastReviewedCommit: b78a3a680b40dff93a7edb464bc7fbd103619352
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/upstream-automation.md
+++ b/docs/upstream-automation.md
@@ -18,7 +18,7 @@ checkPaths:
   - .github/workflows/tag-release-from-merge.yml
   - .docpact/config.yaml
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 2decb1bcb0fc5e5cb24d552b27ddc24cac1eff9a
+lastReviewedCommit: e33751221a477b6065cac0b0e6372aae601973a1
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml


### PR DESCRIPTION
## Summary
- address Codex review feedback from the ai-doc local-gate rollout
- make manual ai-doc/docpact fallback workflows accept an explicit base_ref and fetch remote branches
- make release tag docpact gates compare the tag commit against its parent instead of a base that can collapse to the tag commit
- refresh governance review evidence for the touched workflow guidance docs

## Validation
- YAML workflow parse passed from the workspace root
- local docpact/ai-doc gate passed for this branch

Refs tiangong-lca/workspace#183