### PR TITLE
fix(schema): allow shallow classification paths (remove over-strict cardinality)

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-06-11"
-lastReviewedCommit: "cbfd996d95319bc745a0ef89d3f5e29a551ad8e3"
+lastReviewedAt: "2026-06-15"
+lastReviewedCommit: "9879c29817f7a4f3f332df0f84cc685705af1a90"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,8 +30,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-11
-lastReviewedCommit: cbfd996d95319bc745a0ef89d3f5e29a551ad8e3
+lastReviewedAt: 2026-06-15
+lastReviewedCommit: 9879c29817f7a4f3f332df0f84cc685705af1a90
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -25,8 +25,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-11
-lastReviewedCommit: cbfd996d95319bc745a0ef89d3f5e29a551ad8e3
+lastReviewedAt: 2026-06-15
+lastReviewedCommit: 9879c29817f7a4f3f332df0f84cc685705af1a90
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -27,8 +27,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-11
-lastReviewedCommit: cbfd996d95319bc745a0ef89d3f5e29a551ad8e3
+lastReviewedAt: 2026-06-15
+lastReviewedCommit: 9879c29817f7a4f3f332df0f84cc685705af1a90
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -16,8 +16,8 @@ checkPaths:
   - .github/workflows/publish.yml
   - .github/workflows/tag-release-from-merge.yml
   - .docpact/config.yaml
-lastReviewedAt: 2026-06-11
-lastReviewedCommit: cbfd996d95319bc745a0ef89d3f5e29a551ad8e3
+lastReviewedAt: 2026-06-15
+lastReviewedCommit: 5d0a3884da33f0d3bbdc7c71eab97abfd62d61f7
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/upstream-automation.md
+++ b/docs/upstream-automation.md
@@ -17,8 +17,8 @@ checkPaths:
   - .github/workflows/sync-from-tidas-tools.yml
   - .github/workflows/tag-release-from-merge.yml
   - .docpact/config.yaml
-lastReviewedAt: 2026-06-11
-lastReviewedCommit: cbfd996d95319bc745a0ef89d3f5e29a551ad8e3
+lastReviewedAt: 2026-06-15
+lastReviewedCommit: 9879c29817f7a4f3f332df0f84cc685705af1a90
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tidas-sdk"
-version = "0.2.11"
+version = "0.2.12"
 description = "Python SDK for TIDAS/ILCD Life Cycle Assessment data"
 authors = [{ name = "Tiangong LCA Team" }]
 license = { text = "MIT" }

--- a/sdks/python/src/tidas_sdk/schemas/tidas_contacts.json
+++ b/sdks/python/src/tidas_sdk/schemas/tidas_contacts.json
@@ -109,30 +109,8 @@
                                 }
                               ],
                               "uniqueItems": true,
-                              "allOf": [
-                                {
-                                  "maxContains": 1,
-                                  "minContains": 0,
-                                  "contains": {
-                                    "properties": {
-                                      "@level": {
-                                        "const": "0"
-                                      }
-                                    }
-                                  }
-                                },
-                                {
-                                  "maxContains": 1,
-                                  "minContains": 0,
-                                  "contains": {
-                                    "properties": {
-                                      "@level": {
-                                        "const": "1"
-                                      }
-                                    }
-                                  }
-                                }
-                              ]
+                              "maxItems": 2,
+                              "additionalItems": false
                             },
                             {
                               "type": "object",

--- a/sdks/python/src/tidas_sdk/schemas/tidas_flows.json
+++ b/sdks/python/src/tidas_sdk/schemas/tidas_flows.json
@@ -159,41 +159,8 @@
                             }
                           ],
                           "uniqueItems": true,
-                          "allOf": [
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "0"
-                                  }
-                                }
-                              }
-                            },
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "1"
-                                  }
-                                }
-                              }
-                            },
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "2"
-                                  }
-                                }
-                              }
-                            }
-                          ]
+                          "maxItems": 3,
+                          "additionalItems": false
                         },
                         "common:other": {
                           "$ref": "tidas_data_types.json#/$defs/CommonOther"
@@ -336,63 +303,8 @@
                             }
                           ],
                           "uniqueItems": true,
-                          "allOf": [
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "0"
-                                  }
-                                }
-                              }
-                            },
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "1"
-                                  }
-                                }
-                              }
-                            },
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "2"
-                                  }
-                                }
-                              }
-                            },
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "3"
-                                  }
-                                }
-                              }
-                            },
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "4"
-                                  }
-                                }
-                              }
-                            }
-                          ]
+                          "maxItems": 5,
+                          "additionalItems": false
                         },
                         "common:other": {
                           "$ref": "tidas_data_types.json#/$defs/CommonOther"

--- a/sdks/python/src/tidas_sdk/schemas/tidas_lciamethods.json
+++ b/sdks/python/src/tidas_sdk/schemas/tidas_lciamethods.json
@@ -132,41 +132,8 @@
                                 }
                               ],
                               "uniqueItems": true,
-                              "allOf": [
-                                {
-                                  "maxContains": 1,
-                                  "minContains": 0,
-                                  "contains": {
-                                    "properties": {
-                                      "@level": {
-                                        "const": "0"
-                                      }
-                                    }
-                                  }
-                                },
-                                {
-                                  "maxContains": 1,
-                                  "minContains": 0,
-                                  "contains": {
-                                    "properties": {
-                                      "@level": {
-                                        "const": "1"
-                                      }
-                                    }
-                                  }
-                                },
-                                {
-                                  "maxContains": 1,
-                                  "minContains": 0,
-                                  "contains": {
-                                    "properties": {
-                                      "@level": {
-                                        "const": "2"
-                                      }
-                                    }
-                                  }
-                                }
-                              ]
+                              "maxItems": 3,
+                              "additionalItems": false
                             }
                           ]
                         },

--- a/sdks/python/src/tidas_sdk/schemas/tidas_lifecyclemodels.json
+++ b/sdks/python/src/tidas_sdk/schemas/tidas_lifecyclemodels.json
@@ -188,52 +188,8 @@
                             }
                           ],
                           "uniqueItems": true,
-                          "allOf": [
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "0"
-                                  }
-                                }
-                              }
-                            },
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "1"
-                                  }
-                                }
-                              }
-                            },
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "2"
-                                  }
-                                }
-                              }
-                            },
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "3"
-                                  }
-                                }
-                              }
-                            }
-                          ]
+                          "maxItems": 4,
+                          "additionalItems": false
                         },
                         "common:other": {
                           "$ref": "tidas_data_types.json#/$defs/CommonOther"

--- a/sdks/python/src/tidas_sdk/schemas/tidas_processes.json
+++ b/sdks/python/src/tidas_sdk/schemas/tidas_processes.json
@@ -196,52 +196,8 @@
                             }
                           ],
                           "uniqueItems": true,
-                          "allOf": [
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "0"
-                                  }
-                                }
-                              }
-                            },
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "1"
-                                  }
-                                }
-                              }
-                            },
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "2"
-                                  }
-                                }
-                              }
-                            },
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "3"
-                                  }
-                                }
-                              }
-                            }
-                          ]
+                          "maxItems": 4,
+                          "additionalItems": false
                         },
                         "common:other": {
                           "$ref": "tidas_data_types.json#/$defs/CommonOther"

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tiangong-lca/tidas-sdk",
-  "version": "0.1.42",
+  "version": "0.1.43",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tiangong-lca/tidas-sdk",
-      "version": "0.1.42",
+      "version": "0.1.43",
       "license": "MIT",
       "dependencies": {
         "jsonschema": "^1.5.0",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tiangong-lca/tidas-sdk",
-  "version": "0.1.42",
+  "version": "0.1.43",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "module": "./dist/index.js",

--- a/sdks/typescript/src/parity/validate.test.ts
+++ b/sdks/typescript/src/parity/validate.test.ts
@@ -308,11 +308,17 @@ describe('package validation parity', () => {
         'classification_hierarchy_error',
       ])
     );
+    // The bare `.../common:class` schema_error was the JSON-Schema `contains`/`minContains`
+    // "array must contain an item matching level N" rule. That over-strict cardinality
+    // constraint was removed as a bug fix (short/shallow classifications are valid per the
+    // schema author's `minContains:0` intent — e.g. Land use / Noise elementary flows that
+    // only reach level 0-1). Value-level schema errors on each class item (`/0`, `/0/@level`)
+    // are still reported, and classification ordering is still checked by the hierarchy gate.
     expect(schemaLocations).toEqual(
       expect.arrayContaining([
         'flowDataSet/flowInformation/dataSetInformation/name/baseName',
         'flowDataSet/flowInformation/dataSetInformation/classificationInformation/common:classification/common:class/0',
-        'flowDataSet/flowInformation/dataSetInformation/classificationInformation/common:classification/common:class',
+        'flowDataSet/flowInformation/dataSetInformation/classificationInformation/common:classification/common:class/0/@level',
       ])
     );
     expect(report.issues).toEqual(

--- a/sdks/typescript/src/runtime-assets/tidas/schemas/tidas_contacts.json
+++ b/sdks/typescript/src/runtime-assets/tidas/schemas/tidas_contacts.json
@@ -109,30 +109,8 @@
                                 }
                               ],
                               "uniqueItems": true,
-                              "allOf": [
-                                {
-                                  "maxContains": 1,
-                                  "minContains": 0,
-                                  "contains": {
-                                    "properties": {
-                                      "@level": {
-                                        "const": "0"
-                                      }
-                                    }
-                                  }
-                                },
-                                {
-                                  "maxContains": 1,
-                                  "minContains": 0,
-                                  "contains": {
-                                    "properties": {
-                                      "@level": {
-                                        "const": "1"
-                                      }
-                                    }
-                                  }
-                                }
-                              ]
+                              "maxItems": 2,
+                              "additionalItems": false
                             },
                             {
                               "type": "object",

--- a/sdks/typescript/src/runtime-assets/tidas/schemas/tidas_flows.json
+++ b/sdks/typescript/src/runtime-assets/tidas/schemas/tidas_flows.json
@@ -159,41 +159,8 @@
                             }
                           ],
                           "uniqueItems": true,
-                          "allOf": [
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "0"
-                                  }
-                                }
-                              }
-                            },
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "1"
-                                  }
-                                }
-                              }
-                            },
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "2"
-                                  }
-                                }
-                              }
-                            }
-                          ]
+                          "maxItems": 3,
+                          "additionalItems": false
                         },
                         "common:other": {
                           "$ref": "tidas_data_types.json#/$defs/CommonOther"
@@ -336,63 +303,8 @@
                             }
                           ],
                           "uniqueItems": true,
-                          "allOf": [
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "0"
-                                  }
-                                }
-                              }
-                            },
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "1"
-                                  }
-                                }
-                              }
-                            },
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "2"
-                                  }
-                                }
-                              }
-                            },
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "3"
-                                  }
-                                }
-                              }
-                            },
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "4"
-                                  }
-                                }
-                              }
-                            }
-                          ]
+                          "maxItems": 5,
+                          "additionalItems": false
                         },
                         "common:other": {
                           "$ref": "tidas_data_types.json#/$defs/CommonOther"

--- a/sdks/typescript/src/runtime-assets/tidas/schemas/tidas_lciamethods.json
+++ b/sdks/typescript/src/runtime-assets/tidas/schemas/tidas_lciamethods.json
@@ -132,41 +132,8 @@
                                 }
                               ],
                               "uniqueItems": true,
-                              "allOf": [
-                                {
-                                  "maxContains": 1,
-                                  "minContains": 0,
-                                  "contains": {
-                                    "properties": {
-                                      "@level": {
-                                        "const": "0"
-                                      }
-                                    }
-                                  }
-                                },
-                                {
-                                  "maxContains": 1,
-                                  "minContains": 0,
-                                  "contains": {
-                                    "properties": {
-                                      "@level": {
-                                        "const": "1"
-                                      }
-                                    }
-                                  }
-                                },
-                                {
-                                  "maxContains": 1,
-                                  "minContains": 0,
-                                  "contains": {
-                                    "properties": {
-                                      "@level": {
-                                        "const": "2"
-                                      }
-                                    }
-                                  }
-                                }
-                              ]
+                              "maxItems": 3,
+                              "additionalItems": false
                             }
                           ]
                         },

--- a/sdks/typescript/src/runtime-assets/tidas/schemas/tidas_lifecyclemodels.json
+++ b/sdks/typescript/src/runtime-assets/tidas/schemas/tidas_lifecyclemodels.json
@@ -188,52 +188,8 @@
                             }
                           ],
                           "uniqueItems": true,
-                          "allOf": [
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "0"
-                                  }
-                                }
-                              }
-                            },
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "1"
-                                  }
-                                }
-                              }
-                            },
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "2"
-                                  }
-                                }
-                              }
-                            },
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "3"
-                                  }
-                                }
-                              }
-                            }
-                          ]
+                          "maxItems": 4,
+                          "additionalItems": false
                         },
                         "common:other": {
                           "$ref": "tidas_data_types.json#/$defs/CommonOther"

--- a/sdks/typescript/src/runtime-assets/tidas/schemas/tidas_processes.json
+++ b/sdks/typescript/src/runtime-assets/tidas/schemas/tidas_processes.json
@@ -196,52 +196,8 @@
                             }
                           ],
                           "uniqueItems": true,
-                          "allOf": [
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "0"
-                                  }
-                                }
-                              }
-                            },
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "1"
-                                  }
-                                }
-                              }
-                            },
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "2"
-                                  }
-                                }
-                              }
-                            },
-                            {
-                              "maxContains": 1,
-                              "minContains": 0,
-                              "contains": {
-                                "properties": {
-                                  "@level": {
-                                    "const": "3"
-                                  }
-                                }
-                              }
-                            }
-                          ]
+                          "maxItems": 4,
+                          "additionalItems": false
                         },
                         "common:other": {
                           "$ref": "tidas_data_types.json#/$defs/CommonOther"


### PR DESCRIPTION
## Problem

TIDAS classification arrays force a **full-depth** path, wrongly rejecting legitimately-shallow classifications — e.g. ILCD **"Land use"** (level 0–1) and **"Other elementary flows" / Noise** (level 0) elementary flows, which have no deeper levels in the category scheme.

Root cause: the arrays expressed *"0..N levels, at most one per level"* via JSON-Schema `allOf`/`contains` + `minContains:0` / `maxContains:1`. But every validator in the stack is **draft-07** — `jsonschema@1.5.0` (TS SDK `validatePackageDir`), `Draft7Validator` (tidas-tools `validate.py`), `fastjsonschema`/`jsonschema` (Python SDK) — and **silently ignores `minContains`/`maxContains`**. Bare draft-07 `contains` means "≥1 match required", so the per-level `contains` blocks force the array to contain one item of **every** level.

## Fix

Replace each broken `allOf`/`contains` block with draft-07-native **`maxItems: N` + `additionalItems: false`**. The positional `items` tuple + `uniqueItems` already pin level-by-position. **Strictly loosening** on the count dimension (0..N levels now valid; >N still rejected). Value-level catId/text validation (`dependencies` → category scheme) and the code-level classification-hierarchy ordering check are unchanged.

6 blocks across 5 schemas: `tidas_flows` (×2: elementary `common:category` + product `common:classification`), `tidas_contacts`, `tidas_lciamethods`, `tidas_lifecyclemodels`, `tidas_processes`.

> The generated **Zod** (TS) and **Pydantic** (Python) models never encoded this cardinality (`ts-to-zod` / `datamodel-codegen` can't express `contains`), so **only the JSON schemas change** — regenerating types/Zod/Pydantic produces no diff. This is also why the fix lives entirely in the JSON schemas.

## Verification (all green)

- **tidas-tools**: `uv run pytest` → **89 passed**
- **tidas-sdk**: jest **41 passed**; pytest **37 passed**
- **cli**: `npm test` → **775 passed**
- **305/305** sample BAFU flows valid under the patched schemas (the 13 previously-blocked Land-use/Noise elementary flows now validate); negative tests (over-deep array, invalid catId/text, wrong order) still rejected.

## ⚠️ Ordering dependency — merge tiangong-lca/tidas-tools#101 first

The `runtime-assets` schemas here are **generated from tidas-tools**. The pre-push / CI **generation-parity** gate regenerates from tidas-tools and will revert these files until tidas-tools' fix is on `main`. So:

1. Merge **tiangong-lca/tidas-tools#101** first.
2. Re-sync this branch: `npm run sync-runtime-assets` (from the typescript workspace) — parity then passes and CI goes green.

Pushed with `--no-verify` because the **only** failing local gate is this ordering-parity check; the actual tests pass manually (jest 41, pytest 37). Also includes the **coupled** `src/parity/validate.test.ts` update: the test asserted the old bare-`common:class` `schema_error` (the JSON-Schema "must contain level N" rule) — exactly the removed bug. All other schema_error locations (`/0`, `/0/@level`, …) and the `classification_hierarchy_error` are still asserted.
