### PR TITLE
fix(python): regenerate Pydantic models for classification maxItems (re-release 0.1.44/0.2.13)

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-06-15"
-lastReviewedCommit: "9879c29817f7a4f3f332df0f84cc685705af1a90"
+lastReviewedCommit: "6fe96595b2d86734e749dbf1d68c4cabb24be70a"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-15
-lastReviewedCommit: 9879c29817f7a4f3f332df0f84cc685705af1a90
+lastReviewedCommit: 6fe96595b2d86734e749dbf1d68c4cabb24be70a
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,7 +26,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-15
-lastReviewedCommit: 9879c29817f7a4f3f332df0f84cc685705af1a90
+lastReviewedCommit: 6fe96595b2d86734e749dbf1d68c4cabb24be70a
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-15
-lastReviewedCommit: 9879c29817f7a4f3f332df0f84cc685705af1a90
+lastReviewedCommit: 6fe96595b2d86734e749dbf1d68c4cabb24be70a
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -17,7 +17,7 @@ checkPaths:
   - .github/workflows/tag-release-from-merge.yml
   - .docpact/config.yaml
 lastReviewedAt: 2026-06-15
-lastReviewedCommit: 5d0a3884da33f0d3bbdc7c71eab97abfd62d61f7
+lastReviewedCommit: 6fe96595b2d86734e749dbf1d68c4cabb24be70a
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/upstream-automation.md
+++ b/docs/upstream-automation.md
@@ -18,7 +18,7 @@ checkPaths:
   - .github/workflows/tag-release-from-merge.yml
   - .docpact/config.yaml
 lastReviewedAt: 2026-06-15
-lastReviewedCommit: 9879c29817f7a4f3f332df0f84cc685705af1a90
+lastReviewedCommit: 6fe96595b2d86734e749dbf1d68c4cabb24be70a
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tidas-sdk"
-version = "0.2.12"
+version = "0.2.13"
 description = "Python SDK for TIDAS/ILCD Life Cycle Assessment data"
 authors = [{ name = "Tiangong LCA Team" }]
 license = { text = "MIT" }

--- a/sdks/python/src/tidas_sdk/generated/tidas_lifecyclemodels.py
+++ b/sdks/python/src/tidas_sdk/generated/tidas_lifecyclemodels.py
@@ -50,7 +50,7 @@ class CommonClassItemOption3(TidasBaseModel):
 
 class DataSetInformationClassificationInformationCommonClassification(TidasBaseModel):
     """Optional statistical or other classification of the data set. Typically also used for structuring LCA databases."""
-    common_class: list[CommonClassItemOption0 | CommonClassItemOption1 | CommonClassItemOption2 | CommonClassItemOption3] = Field(default_factory=list, alias='common:class')
+    common_class: list[CommonClassItemOption0 | CommonClassItemOption1 | CommonClassItemOption2 | CommonClassItemOption3] = Field(default_factory=list, alias='common:class', max_items=4)
     common_other: CommonOther | None = Field(default=None, alias='common:other')
 
 class LifeCycleModelInformationDataSetInformationClassificationInformation(TidasBaseModel):

--- a/sdks/python/src/tidas_sdk/generated/tidas_processes.py
+++ b/sdks/python/src/tidas_sdk/generated/tidas_processes.py
@@ -61,7 +61,7 @@ class CommonClassItemOption3(TidasBaseModel):
 
 class DataSetInformationClassificationInformationCommonClassification(TidasBaseModel):
     """Optional statistical or other classification of the data set. Typically also used for structuring LCA databases."""
-    common_class: list[CommonClassItemOption0 | CommonClassItemOption1 | CommonClassItemOption2 | CommonClassItemOption3] = Field(default_factory=list, alias='common:class')
+    common_class: list[CommonClassItemOption0 | CommonClassItemOption1 | CommonClassItemOption2 | CommonClassItemOption3] = Field(default_factory=list, alias='common:class', max_items=4)
     common_other: CommonOther | None = Field(default=None, alias='common:other')
 
 class ProcessInformationDataSetInformationClassificationInformation(TidasBaseModel):

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tiangong-lca/tidas-sdk",
-  "version": "0.1.43",
+  "version": "0.1.44",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tiangong-lca/tidas-sdk",
-      "version": "0.1.43",
+      "version": "0.1.44",
       "license": "MIT",
       "dependencies": {
         "jsonschema": "^1.5.0",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tiangong-lca/tidas-sdk",
-  "version": "0.1.43",
+  "version": "0.1.44",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "module": "./dist/index.js",


### PR DESCRIPTION
Follow-up to #83. The schema cardinality fix replaced `allOf/contains` with `maxItems:N`, which **datamodel-codegen translates to `max_items=N`** on the generated `common_class` Pydantic models for `tidas_processes` and `tidas_lifecyclemodels` (it had ignored the old `allOf/contains`). The committed models were stale, so #83's release failed at *Verify Python package before release tag* (generation-parity) → no tag → no publish (npm stuck 0.1.42, PyPI stuck 0.2.11).

This regenerates the 2 models from patched tidas-tools and re-bumps **TS 0.1.44 / Py 0.2.13** (release detection diffs version commit-to-commit; 0.1.43/0.2.12 are on main but never tagged/published, so a fresh bump is needed to re-trigger). Verified locally: pre-push TS parity + Python verify + tests all pass.