### PR TITLE
fix: make SDK sync lockfile deterministic

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-07-27"
-lastReviewedCommit: "79ea567ff53c297e3f5f604e7b5a65411456d2e5"
+lastReviewedCommit: "a3ea01e7f15f6c1caa2fd134d306094455f6b775"
 
 catalog:
   repos:

--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,8 @@ downloads/
 eggs/
 .eggs/
 lib/
+!scripts/ci/lib/
+!scripts/ci/lib/*.sh
 lib64/
 parts/
 sdist/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-27
-lastReviewedCommit: 79ea567ff53c297e3f5f604e7b5a65411456d2e5
+lastReviewedCommit: a3ea01e7f15f6c1caa2fd134d306094455f6b775
+lastReviewedNote: "Reviewed for issue #89: TypeScript generation and verification now share one lockfile-strict npm dependency installation contract."
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md
@@ -139,6 +140,7 @@ Route those tasks to:
 
 - do not treat `tidas` as the immediate code-generation upstream when package refresh behavior actually depends on `tidas-tools`
 - TypeScript runtime assets are selected and integrity-checked through the upstream Rust `assets/asset-lock.v1.json`; the committed package copy includes that authoritative lock
+- TypeScript generation and verification must install generator dependencies from `sdks/typescript/package-lock.json` through the shared `npm ci --workspaces=false` helper; upstream refreshes must not fall back to `npm install`
 - generated localized-text checks in the TypeScript schemas must keep emitting stable custom validation codes so downstream UIs can map them without parsing prose
 - generated Flow validators must preserve the upstream type-aware name condition: Elementary flows may omit synthetic qualifiers, while Product, Waste, and Other flows require both qualifier fields
 - Python generated models refresh from `tidas-tools`, not from the public docs repository

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ checkPaths:
   - sdks/python/**
   - scripts/ci/**
 lastReviewedAt: 2026-07-27
-lastReviewedCommit: 79ea567ff53c297e3f5f604e7b5a65411456d2e5
+lastReviewedCommit: a3ea01e7f15f6c1caa2fd134d306094455f6b775
+lastReviewedNote: "Reviewed for issue #89: clean TypeScript upstream refreshes are lockfile-strict."
 ---
 
 # TIDAS SDKs
@@ -134,7 +135,9 @@ HEAD to match the exact `TIDAS_TOOLS_SHA` pin:
 The generators validate every asset hash and byte count from
 `assets/asset-lock.v1.json`. The TypeScript refresh derives its runtime roots
 from that catalog and commits a matching `runtime-assets/asset-lock.v1.json`;
-it does not discover assets through the upstream Python package layout.
+it does not discover assets through the upstream Python package layout. When a
+clean refresh needs generator dependencies, it requires the committed
+TypeScript lockfile and installs it with `npm ci --workspaces=false`.
 
 ### Release Workflow
 

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,7 +26,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-27
-lastReviewedCommit: 79ea567ff53c297e3f5f604e7b5a65411456d2e5
+lastReviewedCommit: a3ea01e7f15f6c1caa2fd134d306094455f6b775
+lastReviewedNote: "Reviewed for issue #89: upstream TypeScript generation and verification share the lockfile-strict dependency installer."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -68,6 +69,7 @@ The practical executable chain today is:
 Important consequences:
 
 - `scripts/ci/tidas-tools-assets.mjs` validates the upstream Rust asset lock and derives schema, methodology, and runtime roots from catalog entries rather than package-layout assumptions
+- `scripts/ci/lib/typescript-dependencies.sh` gives clean generation and verification runs the same `npm ci --workspaces=false` dependency graph from the committed TypeScript lockfile
 - TypeScript runtime assets mirror the catalog-selected non-export roots and include the exact authoritative `asset-lock.v1.json`
 - Python generated models also refresh from `tidas-tools`
 - `tidas` remains important for public spec/docs content, but it is not the immediate generation source for current package refreshes

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -28,7 +28,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-27
-lastReviewedCommit: 79ea567ff53c297e3f5f604e7b5a65411456d2e5
+lastReviewedCommit: a3ea01e7f15f6c1caa2fd134d306094455f6b775
+lastReviewedNote: "Reviewed for issue #89: dependency bootstrap regression proof now precedes full TypeScript package verification."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -54,7 +55,7 @@ These scripts are the best repo-wide proof because they mirror CI expectations a
 | --- | --- | --- | --- |
 | TypeScript package source, examples, or package scripts | `./scripts/ci/verify-typescript-package.sh` | run one focused example or narrow package command when the change is isolated | This verify script covers build, tests, generated artifacts, and packability. When the change touches validation behavior, also record one smoke result that proves the normalized `validationIssues` payload still exposes stable `code`, `path`, `severity`, optional `params`, and `rawCode`. |
 | Python package source, scripts, or tests | `./scripts/ci/verify-python-package.sh` | run one focused pytest or generation step when the change is isolated | Record if the Python package still depends on generated artifacts from a specific upstream commit. |
-| shared generation helpers under `scripts/ci/**` | run both verify scripts | run the matching `generate-*.sh` path if the task explicitly changes refresh behavior | Generation changes can affect both packages even if only one output changed. |
+| shared generation helpers under `scripts/ci/**` | run both verify scripts | run the matching focused automation regression script and `generate-*.sh` path if the task explicitly changes refresh behavior | Generation changes can affect both packages even if only one output changed. |
 | release setup, tag, or publish workflows | run both verify scripts | inspect `.github/workflows/**` and record any tag or environment assumptions checked locally | Tag creation and registry publication are separate from local package verification. |
 | repo contract or governed-doc changes only | `scripts/docpact validate-config --root . --strict` and `scripts/docpact lint --root . --staged --mode enforce` | run one focused route check such as `scripts/docpact route --root . --intent repo-docs --format text` or `upstream-refresh` when the change touches release / automation docs | Refresh review evidence even when prose-only governed docs change. |
 
@@ -71,6 +72,9 @@ Facts that matter:
 - `scripts/ci/tidas-tools-assets.mjs` validates the Rust
   `assets/asset-lock.v1.json`, all catalog entry hashes/sizes, and the packaged
   TypeScript runtime copy before generation succeeds
+- clean TypeScript generation and verification both install dependencies through
+  `scripts/ci/lib/typescript-dependencies.sh`, which requires the committed
+  lockfile and runs `npm ci --workspaces=false`
 - if you intentionally validate against a local checkout, record both its path
   and exact commit in the PR note
 

--- a/docs/release-setup.md
+++ b/docs/release-setup.md
@@ -17,7 +17,7 @@ checkPaths:
   - .github/workflows/tag-release-from-merge.yml
   - .docpact/config.yaml
 lastReviewedAt: 2026-07-27
-lastReviewedCommit: 79ea567ff53c297e3f5f604e7b5a65411456d2e5
+lastReviewedCommit: a3ea01e7f15f6c1caa2fd134d306094455f6b775
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/docs/upstream-automation.md
+++ b/docs/upstream-automation.md
@@ -18,7 +18,8 @@ checkPaths:
   - .github/workflows/tag-release-from-merge.yml
   - .docpact/config.yaml
 lastReviewedAt: 2026-07-27
-lastReviewedCommit: 79ea567ff53c297e3f5f604e7b5a65411456d2e5
+lastReviewedCommit: a3ea01e7f15f6c1caa2fd134d306094455f6b775
+lastReviewedNote: "Reviewed for issue #89: clean upstream refreshes use the same lockfile-strict TypeScript dependency graph as verification."
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -126,17 +127,19 @@ Recommended responsibilities:
 1. check out `tidas-sdk`
 2. check out `tiangong-lca/tidas-tools` at `client_payload.tidas_tools_sha`
 3. verify that checkout against its Rust `assets/asset-lock.v1.json`
-4. regenerate SDKs with:
+4. install TypeScript generator dependencies from the committed lockfile through
+   `npm ci --workspaces=false`
+5. regenerate SDKs with:
    - `TIDAS_TOOLS_SOURCE_MODE=auto`
    - `TIDAS_TOOLS_PATH=<checked out tools path>`
    - `TIDAS_TOOLS_SHA=<checked out exact commit>`
-5. run local parity checks:
+6. run local parity checks:
    - `./scripts/ci/verify-typescript-package.sh`
    - `./scripts/ci/verify-python-package.sh`
-6. detect whether TypeScript and/or Python outputs changed
-7. bump only the affected package version(s) to the next unpublished version in the target registry
-8. commit changes to a bot branch
-9. open or update a release-prep PR against `main`
+7. detect whether TypeScript and/or Python outputs changed
+8. bump only the affected package version(s) to the next unpublished version in the target registry
+9. commit changes to a bot branch
+10. open or update a release-prep PR against `main`
 
 Validation-contract safeguard for TypeScript refreshes:
 

--- a/scripts/ci/generate-typescript-sdk.sh
+++ b/scripts/ci/generate-typescript-sdk.sh
@@ -13,6 +13,7 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 OUTPUT_DIR="${OUTPUT_DIR:-$REPO_ROOT/sdks/typescript/src}"
 SDK_ROOT="${SDK_ROOT:-$REPO_ROOT/sdks/typescript}"
 source "$SCRIPT_DIR/lib/tidas-tools-source.sh"
+source "$SCRIPT_DIR/lib/typescript-dependencies.sh"
 TIDAS_TOOLS_ASSET_RESOLVER="$SCRIPT_DIR/tidas-tools-assets.mjs"
 
 # 颜色输出
@@ -110,9 +111,7 @@ check_dependencies() {
     # 检查是否安装了依赖
     if [ ! -d "$SDK_ROOT/node_modules" ]; then
         log_warn "node_modules not found, installing dependencies..."
-        cd "$SDK_ROOT"
-        npm install
-        cd - > /dev/null
+        install_typescript_dependencies "$SDK_ROOT"
     fi
 
     log_info "✓ All dependencies satisfied"

--- a/scripts/ci/lib/typescript-dependencies.sh
+++ b/scripts/ci/lib/typescript-dependencies.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+install_typescript_dependencies() {
+    local sdk_root="${1:?TypeScript SDK root is required}"
+
+    if [ ! -f "$sdk_root/package.json" ]; then
+        echo "error: package.json not found in $sdk_root" >&2
+        return 1
+    fi
+
+    if [ ! -f "$sdk_root/package-lock.json" ]; then
+        echo "error: package-lock.json not found in $sdk_root" >&2
+        return 1
+    fi
+
+    if ! command -v npm >/dev/null 2>&1; then
+        echo "error: npm not found" >&2
+        return 1
+    fi
+
+    (
+        cd "$sdk_root"
+        npm ci --workspaces=false
+    )
+}

--- a/scripts/ci/test-typescript-dependencies.sh
+++ b/scripts/ci/test-typescript-dependencies.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/typescript-dependencies.sh"
+
+test_root="$(mktemp -d)"
+npm_log="$test_root/npm.log"
+trap 'find "$test_root" -depth -delete' EXIT
+
+sdk_root="$test_root/typescript"
+mkdir -p "$sdk_root"
+: >"$sdk_root/package.json"
+: >"$sdk_root/package-lock.json"
+
+npm() {
+    printf '%s|%s\n' "$PWD" "$*" >>"$npm_log"
+}
+
+install_typescript_dependencies "$sdk_root"
+
+expected="$sdk_root|ci --workspaces=false"
+actual="$(cat "$npm_log")"
+if [ "$actual" != "$expected" ]; then
+    echo "error: expected '$expected', got '$actual'" >&2
+    exit 1
+fi
+
+find "$sdk_root/package-lock.json" -depth -delete
+if install_typescript_dependencies "$sdk_root" >"$test_root/missing-lock.stdout" 2>"$test_root/missing-lock.stderr"; then
+    echo "error: dependency installation succeeded without package-lock.json" >&2
+    exit 1
+fi
+
+if ! grep -Fq "package-lock.json not found" "$test_root/missing-lock.stderr"; then
+    echo "error: missing lockfile failure did not explain the contract" >&2
+    exit 1
+fi
+
+if [ "$(wc -l <"$npm_log" | tr -d ' ')" != "1" ]; then
+    echo "error: npm was invoked after the lockfile check failed" >&2
+    exit 1
+fi
+
+grep -Fq 'install_typescript_dependencies "$SDK_ROOT"' "$SCRIPT_DIR/generate-typescript-sdk.sh"
+grep -Fq 'install_typescript_dependencies "$TS_ROOT"' "$SCRIPT_DIR/verify-typescript-package.sh"
+
+echo "TypeScript dependency installation contract passed."

--- a/scripts/ci/verify-typescript-package.sh
+++ b/scripts/ci/verify-typescript-package.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 TS_ROOT="$REPO_ROOT/sdks/typescript"
+source "$SCRIPT_DIR/lib/typescript-dependencies.sh"
 
 snapshot_path_state() {
     local target="$1"
@@ -28,10 +29,7 @@ require_stable_generation_output() {
 }
 
 echo "[typescript] installing dependencies"
-(
-    cd "$TS_ROOT"
-    npm ci --workspaces=false
-)
+install_typescript_dependencies "$TS_ROOT"
 
 before_generated_state="$(snapshot_path_state "sdks/typescript/src")"
 


### PR DESCRIPTION
Closes tiangong-lca/tidas-sdk#89

## Summary
- Use one shared lockfile-strict TypeScript dependency installer for clean upstream generation and package verification.
- Add focused regression coverage for the npm ci command, lockfile requirement, and both automation callers.

## Key Decisions
- Keep the stable-generation guard intact; eliminate the dependency-graph mismatch instead of weakening deterministic output checks.
- Use npm ci --workspaces=false from sdks/typescript/package-lock.json for both generation bootstrap and verification.

## Validation
- ./scripts/ci/test-typescript-dependencies.sh
- Docpact validate-config --strict and worktree lint --mode enforce (zero findings).
- ./scripts/ci/verify-python-package.sh against tidas-tools 0d3170f3f4af0f25a63be49ff63585af1b53f76b: 41 tests, build, and twine checks passed.
- Clean-worktree dispatch reproduction against the same upstream SHA: initial TypeScript generation, Python generation, 0.1.46 version bump, and ./scripts/ci/verify-typescript-package.sh all passed through npm pack.

## Risks / Rollback
- Low and isolated to clean TypeScript dependency bootstrap; existing developer node_modules reuse is unchanged, and missing lockfiles now fail explicitly.

## Follow-ups
- After merge, rerun tidas-sdk repository-dispatch for tidas-tools 0d3170f3f4af0f25a63be49ff63585af1b53f76b and review the generated SDK refresh PR.

## Workspace Integration
- The merged automation fix and subsequent SDK refresh must be pinned by tiangong-lca/workspace#485 before final cutover completion.